### PR TITLE
connector: create AWSReader interface on top

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ GOFILES_NOVENDOR := $(shell find . -type f -name '*.go' -not -path "./vendor/*" 
 .PHONY: get-deps
 get-deps:
 	go get -t ./...
+	go get golang.org/x/tools/cmd/goimports
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ To get started, you can download/include the library to your code:
 import 	"github.com/cycloidio/raws"
 ```
 
-### Create a connector
+### Create a reader
 ```go
 var config *aws.Config = nil
 var accessKey string = "xxxxxxxxxxxxxxxx"
 var secretKey string = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 var region []string = []string{"eu-*"}
 
-c, err := raws.NewConnector(accessKey, secretKey, region, config)
+c, err := raws.NewAWSReader(accessKey, secretKey, region, config)
 if err != nil {
 	fmt.Printf("Error while getting NewConnector: %s\n", err.Error())
 	return err

--- a/connector.go
+++ b/connector.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 )
@@ -106,14 +107,15 @@ func (c *connector) GetRegions() []string {
 }
 
 type serviceConnector struct {
-	region      string
-	session     *session.Session
-	ec2         ec2iface.EC2API
-	elb         elbiface.ELBAPI
-	elbv2       elbv2iface.ELBV2API
-	rds         rdsiface.RDSAPI
-	s3          s3iface.S3API
-	elasticache elasticacheiface.ElastiCacheAPI
+	region       string
+	session      *session.Session
+	ec2          ec2iface.EC2API
+	elb          elbiface.ELBAPI
+	elbv2        elbv2iface.ELBV2API
+	rds          rdsiface.RDSAPI
+	s3           s3iface.S3API
+	s3downloader s3manageriface.DownloaderAPI
+	elasticache  elasticacheiface.ElastiCacheAPI
 }
 
 func configureAWS(accessKey string, secretKey string) (*credentials.Credentials, ec2iface.EC2API, stsiface.STSAPI, error) {

--- a/connector.go
+++ b/connector.go
@@ -1,40 +1,71 @@
 package raws
 
 import (
-	"path/filepath"
-
-	"fmt"
-
 	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
+	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elasticache/elasticacheiface"
+	"github.com/aws/aws-sdk-go/service/elb"
 	"github.com/aws/aws-sdk-go/service/elb/elbiface"
+	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/elbv2/elbv2iface"
+	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 )
 
-// The Connector provides easy access to AWS SDK calls.
+// AWSReader is the interface defining all methods that need to be implemented
+type AWSReader interface {
+	GetAccountID() string
+	GetRegions() []string
+	GetInstances(input *ec2.DescribeInstancesInput) ([]*ec2.DescribeInstancesOutput, Errs)
+	GetVpcs(input *ec2.DescribeVpcsInput) ([]*ec2.DescribeVpcsOutput, Errs)
+	GetImages(input *ec2.DescribeImagesInput) ([]*ec2.DescribeImagesOutput, Errs)
+	GetSecurityGroups(input *ec2.DescribeSecurityGroupsInput) ([]*ec2.DescribeSecurityGroupsOutput, Errs)
+	GetSubnets(input *ec2.DescribeSubnetsInput) ([]*ec2.DescribeSubnetsOutput, Errs)
+	GetVolumes(input *ec2.DescribeVolumesInput) ([]*ec2.DescribeVolumesOutput, Errs)
+	GetSnapshots(input *ec2.DescribeSnapshotsInput) ([]*ec2.DescribeSnapshotsOutput, Errs)
+	GetElasticCacheCluster(input *elasticache.DescribeCacheClustersInput) ([]*elasticache.DescribeCacheClustersOutput, Errs)
+	GetElasticacheTags(input *elasticache.ListTagsForResourceInput) ([]*elasticache.TagListMessage, Errs)
+	GetLoadBalancers(input *elb.DescribeLoadBalancersInput) ([]*elb.DescribeLoadBalancersOutput, Errs)
+	GetLoadBalancersTags(input *elb.DescribeTagsInput) ([]*elb.DescribeTagsOutput, Errs)
+	GetLoadBalancersV2(input *elbv2.DescribeLoadBalancersInput) ([]*elbv2.DescribeLoadBalancersOutput, Errs)
+	GetLoadBalancersV2Tags(input *elbv2.DescribeTagsInput) ([]*elbv2.DescribeTagsOutput, Errs)
+	GetDBInstances(input *rds.DescribeDBInstancesInput) ([]*rds.DescribeDBInstancesOutput, Errs)
+	GetDBInstancesTags(input *rds.ListTagsForResourceInput) ([]*rds.ListTagsForResourceOutput, Errs)
+	ListBuckets(input *s3.ListBucketsInput) ([]*s3.ListBucketsOutput, Errs)
+	GetBucketTags(input *s3.GetBucketTaggingInput) ([]*s3.GetBucketTaggingOutput, Errs)
+	ListObjects(input *s3.ListObjectsInput) ([]*s3.ListObjectsOutput, Errs)
+	DownloadObject(w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (int64, error)
+	GetObjectsTags(input *s3.GetObjectTaggingInput) ([]*s3.GetObjectTaggingOutput, Errs)
+}
+
+// The connector provides easy access to AWS SDK calls.
 //
 // By using it, calls can be made directly through multiple regions, and will filter only data that belongs to you.
 // For example, when fetching the list of AMI, or snapshots.
 //
-// In order to start making calls, only calling NewConnector is required.
-type Connector struct {
+// In order to start making calls, only calling NewAWSReader is required.
+type connector struct {
 	regions   []string
 	svcs      []*serviceConnector
 	creds     *credentials.Credentials
 	accountID *string
 }
 
-// NewConnector returns an object which also contains the accountID and extend the different regions to use.
+// NewAWSReader returns an object which also contains the accountID and extend the different regions to use.
 //
 // The accountID is helpful to return only the AMI or snapshots that belong to the account.
 //
@@ -46,8 +77,8 @@ type Connector struct {
 //
 // The connections are not all established while instancing, but the various sessions are, this way connections are only
 // made for services that are called, otherwise only the sessions remain.
-func NewConnector(accessKey string, secretKey string, regions []string, config *aws.Config) (*Connector, error) {
-	var c Connector = Connector{}
+func NewAWSReader(accessKey string, secretKey string, regions []string, config *aws.Config) (AWSReader, error) {
+	var c connector = connector{}
 
 	creds, ec2, sts, err := configureAWS(accessKey, secretKey)
 	if err != nil {
@@ -62,6 +93,16 @@ func NewConnector(accessKey string, secretKey string, regions []string, config *
 	}
 	c.setServices(config)
 	return &c, nil
+}
+
+// GetAccountID returns the current ID for the account used
+func (c *connector) GetAccountID() string {
+	return *c.accountID
+}
+
+// GetRegions return the currently used regions for the Connector
+func (c *connector) GetRegions() []string {
+	return c.regions
 }
 
 type serviceConnector struct {
@@ -102,7 +143,7 @@ func configureAWS(accessKey string, secretKey string) (*credentials.Credentials,
 	return creds, ec2.New(session), sts.New(session), nil
 }
 
-func (c *Connector) setRegions(ec2 ec2iface.EC2API, enabledRegions []string) error {
+func (c *connector) setRegions(ec2 ec2iface.EC2API, enabledRegions []string) error {
 	if len(enabledRegions) == 0 {
 		return errors.New("at least one region name is required")
 	}
@@ -123,7 +164,7 @@ func (c *Connector) setRegions(ec2 ec2iface.EC2API, enabledRegions []string) err
 	return nil
 }
 
-func (c *Connector) setAccountID(sts stsiface.STSAPI) error {
+func (c *connector) setAccountID(sts stsiface.STSAPI) error {
 	resp, err := sts.GetCallerIdentity(nil)
 	if err != nil {
 		return err
@@ -132,7 +173,7 @@ func (c *Connector) setAccountID(sts stsiface.STSAPI) error {
 	return nil
 }
 
-func (c *Connector) setServices(config *aws.Config) {
+func (c *connector) setServices(config *aws.Config) {
 	if config != nil {
 		config.Credentials = c.creds
 	} else {

--- a/connector_test.go
+++ b/connector_test.go
@@ -66,7 +66,7 @@ func TestConnector_setRegion(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{}
+		c := &connector{}
 		err := c.setRegions(tt.mocked, tt.regionsInput)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(c.regions, tt.expectedRegions) {
@@ -103,7 +103,7 @@ func TestConnector_setAccountID(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{}
+		c := &connector{}
 		err := c.setAccountID(tt.mocked)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(c.accountID, tt.expectedID) {
@@ -158,7 +158,7 @@ func TestConnector_setServices(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{
+		c := &connector{
 			regions: tt.regionsInput,
 			creds:   tt.credsInput,
 		}

--- a/ec2.go
+++ b/ec2.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Returns all EC2 instances based on the input given
-func (c *Connector) GetInstances(input *ec2.DescribeInstancesInput) ([]*ec2.DescribeInstancesOutput, Errs) {
+func (c *connector) GetInstances(input *ec2.DescribeInstancesInput) ([]*ec2.DescribeInstancesOutput, Errs) {
 	var errs Errs
 	var instances []*ec2.DescribeInstancesOutput
 
@@ -24,7 +24,7 @@ func (c *Connector) GetInstances(input *ec2.DescribeInstancesInput) ([]*ec2.Desc
 }
 
 // Returns all EC2 VPCs based on the input given
-func (c *Connector) GetVpcs(input *ec2.DescribeVpcsInput) ([]*ec2.DescribeVpcsOutput, Errs) {
+func (c *connector) GetVpcs(input *ec2.DescribeVpcsInput) ([]*ec2.DescribeVpcsOutput, Errs) {
 	var errs Errs
 	var vpcs []*ec2.DescribeVpcsOutput
 
@@ -43,7 +43,7 @@ func (c *Connector) GetVpcs(input *ec2.DescribeVpcsInput) ([]*ec2.DescribeVpcsOu
 }
 
 // Returns all EC2 AMI belonging to the Account ID based on the input given
-func (c *Connector) GetImages(input *ec2.DescribeImagesInput) ([]*ec2.DescribeImagesOutput, Errs) {
+func (c *connector) GetImages(input *ec2.DescribeImagesInput) ([]*ec2.DescribeImagesOutput, Errs) {
 	var errs Errs
 	var images []*ec2.DescribeImagesOutput
 
@@ -66,7 +66,7 @@ func (c *Connector) GetImages(input *ec2.DescribeImagesInput) ([]*ec2.DescribeIm
 }
 
 // Returns all EC2 security groups based on the input given
-func (c *Connector) GetSecurityGroups(input *ec2.DescribeSecurityGroupsInput) ([]*ec2.DescribeSecurityGroupsOutput, Errs) {
+func (c *connector) GetSecurityGroups(input *ec2.DescribeSecurityGroupsInput) ([]*ec2.DescribeSecurityGroupsOutput, Errs) {
 	var errs Errs
 	var secgroups []*ec2.DescribeSecurityGroupsOutput
 
@@ -85,7 +85,7 @@ func (c *Connector) GetSecurityGroups(input *ec2.DescribeSecurityGroupsInput) ([
 }
 
 // Returns all EC2 subnets based on the input given
-func (c *Connector) GetSubnets(input *ec2.DescribeSubnetsInput) ([]*ec2.DescribeSubnetsOutput, Errs) {
+func (c *connector) GetSubnets(input *ec2.DescribeSubnetsInput) ([]*ec2.DescribeSubnetsOutput, Errs) {
 	var errs Errs
 	var subnets []*ec2.DescribeSubnetsOutput
 
@@ -104,7 +104,7 @@ func (c *Connector) GetSubnets(input *ec2.DescribeSubnetsInput) ([]*ec2.Describe
 }
 
 // Returns all EC2 volumes based on the input given
-func (c *Connector) GetVolumes(input *ec2.DescribeVolumesInput) ([]*ec2.DescribeVolumesOutput, Errs) {
+func (c *connector) GetVolumes(input *ec2.DescribeVolumesInput) ([]*ec2.DescribeVolumesOutput, Errs) {
 	var errs Errs
 	var volumes []*ec2.DescribeVolumesOutput
 
@@ -123,7 +123,7 @@ func (c *Connector) GetVolumes(input *ec2.DescribeVolumesInput) ([]*ec2.Describe
 }
 
 // Returns all snapshots belonging to the Account ID based on the input given
-func (c *Connector) GetSnapshots(input *ec2.DescribeSnapshotsInput) ([]*ec2.DescribeSnapshotsOutput, Errs) {
+func (c *connector) GetSnapshots(input *ec2.DescribeSnapshotsInput) ([]*ec2.DescribeSnapshotsOutput, Errs) {
 	var errs Errs
 	var snapshots []*ec2.DescribeSnapshotsOutput
 

--- a/ec2_test.go
+++ b/ec2_test.go
@@ -200,7 +200,7 @@ func TestGetInstances(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		instances, err := c.GetInstances(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(instances, tt.expectedInstances) {
@@ -331,7 +331,7 @@ func TestGetVpcs(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		vpcs, err := c.GetVpcs(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(vpcs, tt.expectedVpcs) {
@@ -462,7 +462,7 @@ func TestGetImages(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		images, err := c.GetImages(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(images, tt.expectedImages) {
@@ -593,7 +593,7 @@ func TestGetSecurityGroups(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		secGroups, err := c.GetSecurityGroups(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(secGroups, tt.expectedSecGroups) {
@@ -724,7 +724,7 @@ func TestGetSubnets(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		subnets, err := c.GetSubnets(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(subnets, tt.expectedSubnets) {
@@ -855,7 +855,7 @@ func TestGetVolumes(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		volumes, err := c.GetVolumes(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(volumes, tt.expectedVolumes) {
@@ -990,7 +990,7 @@ func TestGetSnapshots(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		snapshots, err := c.GetSnapshots(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(snapshots, tt.expectedSnapshots) {

--- a/elasticache.go
+++ b/elasticache.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Returns all Elasticache clusters based on the input given
-func (c *Connector) GetElasticCacheCluster(input *elasticache.DescribeCacheClustersInput) ([]*elasticache.DescribeCacheClustersOutput, Errs) {
+func (c *connector) GetElasticCacheCluster(input *elasticache.DescribeCacheClustersInput) ([]*elasticache.DescribeCacheClustersOutput, Errs) {
 	var errs Errs
 	var elasticCacheClusters []*elasticache.DescribeCacheClustersOutput
 
@@ -24,7 +24,7 @@ func (c *Connector) GetElasticCacheCluster(input *elasticache.DescribeCacheClust
 }
 
 // Returns a list of tags of Elasticache resources based on its ARN
-func (c *Connector) GetElasticacheTags(input *elasticache.ListTagsForResourceInput) ([]*elasticache.TagListMessage, Errs) {
+func (c *connector) GetElasticacheTags(input *elasticache.ListTagsForResourceInput) ([]*elasticache.TagListMessage, Errs) {
 	var errs Errs
 	var elastiCacheTags []*elasticache.TagListMessage
 

--- a/elasticache_test.go
+++ b/elasticache_test.go
@@ -170,7 +170,7 @@ func TestGetElasticacheCluster(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		cluster, err := c.GetElasticCacheCluster(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(cluster, tt.expectedClusters) {
@@ -328,7 +328,7 @@ func TestGetElasticacheTags(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		tags, err := c.GetElasticacheTags(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(tags, tt.expectedTags) {

--- a/elb.go
+++ b/elb.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Returns a list of ELB (v1) based on the input from the different regions
-func (c *Connector) GetLoadBalancers(input *elb.DescribeLoadBalancersInput) ([]*elb.DescribeLoadBalancersOutput, Errs) {
+func (c *connector) GetLoadBalancers(input *elb.DescribeLoadBalancersInput) ([]*elb.DescribeLoadBalancersOutput, Errs) {
 	var elbs []*elb.DescribeLoadBalancersOutput
 	var errs Errs
 
@@ -24,7 +24,7 @@ func (c *Connector) GetLoadBalancers(input *elb.DescribeLoadBalancersInput) ([]*
 }
 
 // Returns a list of Tags based on the input from the different regions
-func (c *Connector) GetLoadBalancersTags(input *elb.DescribeTagsInput) ([]*elb.DescribeTagsOutput, Errs) {
+func (c *connector) GetLoadBalancersTags(input *elb.DescribeTagsInput) ([]*elb.DescribeTagsOutput, Errs) {
 	var elbTags []*elb.DescribeTagsOutput
 	var errs Errs
 

--- a/elb_test.go
+++ b/elb_test.go
@@ -171,7 +171,7 @@ func TestGetLoadBalancers(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		elbs, err := c.GetLoadBalancers(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(elbs, tt.expectedELBs) {
@@ -321,7 +321,7 @@ func TestGetLoadBalancersTags(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		tags, err := c.GetLoadBalancersTags(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(tags, tt.expectedTags) {

--- a/elbv2.go
+++ b/elbv2.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Returns a list of ELB (v2) - also known as ALB - based on the input from the different regions
-func (c *Connector) GetLoadBalancersV2(input *elbv2.DescribeLoadBalancersInput) ([]*elbv2.DescribeLoadBalancersOutput, Errs) {
+func (c *connector) GetLoadBalancersV2(input *elbv2.DescribeLoadBalancersInput) ([]*elbv2.DescribeLoadBalancersOutput, Errs) {
 	var errs Errs
 	var elbs []*elbv2.DescribeLoadBalancersOutput
 
@@ -24,7 +24,7 @@ func (c *Connector) GetLoadBalancersV2(input *elbv2.DescribeLoadBalancersInput) 
 }
 
 // Returns a list of Tags based on the input from the different regions
-func (c *Connector) GetLoadBalancersV2Tags(input *elbv2.DescribeTagsInput) ([]*elbv2.DescribeTagsOutput, Errs) {
+func (c *connector) GetLoadBalancersV2Tags(input *elbv2.DescribeTagsInput) ([]*elbv2.DescribeTagsOutput, Errs) {
 	var errs Errs
 	var elbTags []*elbv2.DescribeTagsOutput
 

--- a/elbv2_test.go
+++ b/elbv2_test.go
@@ -171,7 +171,7 @@ func TestGetLoadBalancersV2(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		elbs, err := c.GetLoadBalancersV2(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(elbs, tt.expectedELBs) {
@@ -321,7 +321,7 @@ func TestGetLoadBalancersV2Tags(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		tags, err := c.GetLoadBalancersV2Tags(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(tags, tt.expectedTags) {

--- a/example/main.go
+++ b/example/main.go
@@ -69,7 +69,7 @@ func callS3(c raws.AWSReader) {
 	bucketsTags, _ := c.GetBucketTags(i)
 	fmt.Println(bucketsTags)
 	i2 := &s3.ListObjectsInput{Bucket: aws.String("MY_BUCKET")}
-	objects, _ := c.GetObjects(i2)
+	objects, _ := c.ListObjects(i2)
 	fmt.Println(objects)
 	i3 := &s3.GetObjectTaggingInput{
 		Bucket: aws.String("MY_BUCKET"),

--- a/example/main.go
+++ b/example/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cycloidio/raws"
 )
 
-func callEC2(c *raws.Connector) {
+func callEC2(c raws.AWSReader) {
 	instances, _ := c.GetInstances(nil)
 	fmt.Println(instances)
 	vpcs, _ := c.GetVpcs(nil)
@@ -27,21 +27,21 @@ func callEC2(c *raws.Connector) {
 	fmt.Println(snapshots)
 }
 
-func callELB(c *raws.Connector) {
+func callELB(c raws.AWSReader) {
 	elbs, _ := c.GetLoadBalancers(nil)
 	fmt.Println(elbs)
 	tags, _ := c.GetLoadBalancersTags(nil)
 	fmt.Println(tags)
 }
 
-func callELBv2(c *raws.Connector) {
+func callELBv2(c raws.AWSReader) {
 	elbs, _ := c.GetLoadBalancersV2(nil)
 	fmt.Println(elbs)
 	tags, _ := c.GetLoadBalancersV2Tags(nil)
 	fmt.Println(tags)
 }
 
-func callRDS(c *raws.Connector) {
+func callRDS(c raws.AWSReader) {
 	instances, _ := c.GetDBInstances(nil)
 	fmt.Println(instances)
 	i := &rds.ListTagsForResourceInput{
@@ -51,7 +51,7 @@ func callRDS(c *raws.Connector) {
 	fmt.Println(tags)
 }
 
-func callElastiCache(c *raws.Connector) {
+func callElastiCache(c raws.AWSReader) {
 	clusters, _ := c.GetElasticCacheCluster(nil)
 
 	fmt.Println(clusters)
@@ -62,8 +62,8 @@ func callElastiCache(c *raws.Connector) {
 	fmt.Println(tags)
 }
 
-func callS3(c *raws.Connector) {
-	buckets, _ := c.GetBuckets(nil)
+func callS3(c raws.AWSReader) {
+	buckets, _ := c.ListBuckets(nil)
 	fmt.Println(buckets)
 	i := &s3.GetBucketTaggingInput{Bucket: aws.String("MY_BUCKET")}
 	bucketsTags, _ := c.GetBucketTags(i)
@@ -84,7 +84,7 @@ func main() {
 	secretKey := ""
 	region := []string{"eu-*"}
 
-	c, err := raws.NewConnector(accessKey, secretKey, region, nil)
+	c, err := raws.NewAWSReader(accessKey, secretKey, region, nil)
 	if err != nil {
 		fmt.Printf("Error while getting NewConnector: %s\n", err.Error())
 		return

--- a/rds.go
+++ b/rds.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Returns all DB instances based on the input given
-func (c *Connector) GetDBInstances(input *rds.DescribeDBInstancesInput) ([]*rds.DescribeDBInstancesOutput, Errs) {
+func (c *connector) GetDBInstances(input *rds.DescribeDBInstancesInput) ([]*rds.DescribeDBInstancesOutput, Errs) {
 	var errs Errs
 	var instances []*rds.DescribeDBInstancesOutput
 
@@ -25,7 +25,7 @@ func (c *Connector) GetDBInstances(input *rds.DescribeDBInstancesInput) ([]*rds.
 
 // Returns a list of tags from an ARN, extra filters for tags can also be provided
 // For more information, please see: https://docs.aws.amazon.com/sdk-for-go/api/service/rds/#Filter
-func (c *Connector) GetDBInstancesTags(input *rds.ListTagsForResourceInput) ([]*rds.ListTagsForResourceOutput, Errs) {
+func (c *connector) GetDBInstancesTags(input *rds.ListTagsForResourceInput) ([]*rds.ListTagsForResourceOutput, Errs) {
 	var errs Errs
 	var rdsTags []*rds.ListTagsForResourceOutput
 

--- a/rds_test.go
+++ b/rds_test.go
@@ -172,7 +172,7 @@ func TestGetDBInstances(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		instances, err := c.GetDBInstances(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(instances, tt.expectedInstances) {
@@ -333,7 +333,7 @@ func TestGetDBInstancesTags(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		tags, err := c.GetDBInstancesTags(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(tags, tt.expectedTags) {

--- a/s3.go
+++ b/s3.go
@@ -79,7 +79,7 @@ func (c *connector) DownloadObject(w io.WriterAt, input *s3.GetObjectInput, opti
 			return n, nil
 		}
 	}
-	return n, fmt.Errorf("Couldn't download '%v' in any of '%v' regions", input, c.GetRegions())
+	return n, fmt.Errorf("Couldn't download '%+v' in any of '%+v' regions", input, c.GetRegions())
 }
 
 // Returns tags associated with S3 objects based on the input given

--- a/s3.go
+++ b/s3.go
@@ -67,9 +67,12 @@ func (c *connector) ListObjects(input *s3.ListObjectsInput) ([]*s3.ListObjectsOu
 
 // DownloadObject downloads an object in a bucket based on the input given
 func (c *connector) DownloadObject(w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader)) (int64, error) {
-	var err error = nil
-	var n int64 = 0
+	var err error
+	var n int64
 
+	if input.Bucket == nil || input.Key == nil {
+		return n, fmt.Errorf("couldn't download undefined object (keys or bucket not set)")
+	}
 	for _, svc := range c.svcs {
 		if svc.s3downloader == nil {
 			svc.s3downloader = s3manager.NewDownloader(svc.session)
@@ -79,7 +82,7 @@ func (c *connector) DownloadObject(w io.WriterAt, input *s3.GetObjectInput, opti
 			return n, nil
 		}
 	}
-	return n, fmt.Errorf("Couldn't download '%+v' in any of '%+v' regions", input, c.GetRegions())
+	return n, fmt.Errorf("couldn't download '%s/%s' in any of '%+v' regions", *input.Bucket, *input.Key, c.GetRegions())
 }
 
 // Returns tags associated with S3 objects based on the input given

--- a/s3_test.go
+++ b/s3_test.go
@@ -168,8 +168,8 @@ func TestGetBuckets(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
-		buckets, err := c.GetBuckets(nil)
+		c := &connector{svcs: tt.mocked}
+		buckets, err := c.ListBuckets(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(buckets, tt.expectedBuckets) {
 			t.Errorf("%s [%d] - S3 buckets: received=%+v | expected=%+v",
@@ -307,7 +307,7 @@ func TestGetBucketTags(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		tags, err := c.GetBucketTags(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(tags, tt.expectedTags) {
@@ -421,8 +421,8 @@ func TestGetObjets(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
-		objects, err := c.GetObjects(nil)
+		c := &connector{svcs: tt.mocked}
+		objects, err := c.ListObjects(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(objects, tt.expectedObjects) {
 			t.Errorf("%s [%d] - S3 objects: received=%+v | expected=%+v",
@@ -536,7 +536,7 @@ func TestObjectsTags(t *testing.T) {
 		}}
 
 	for i, tt := range tests {
-		c := &Connector{svcs: tt.mocked}
+		c := &connector{svcs: tt.mocked}
 		tags, err := c.GetObjectsTags(nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(tags, tt.expectedTags) {


### PR DESCRIPTION
The Connector type was exported but, that didn't make the usage of it from other package/project easy; as some elements were also unexported, and couldn't be set via exported methods.

The doc, examples & billing package have been updated in order to reflect this change.

Closes: https://github.com/cycloidio/raws/issues/5
