### PR TITLE
example: Make example/main an Example function

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,8 @@
-package main
+package raws_test
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -79,9 +80,20 @@ func callS3(c raws.AWSReader) {
 	fmt.Println(objectsTags)
 }
 
-func main() {
-	accessKey := ""
-	secretKey := ""
+func Example() {
+	var ok bool
+	var accessKey string
+	if accessKey, ok = os.LookupEnv("AWS_ACCESS_KEY"); !ok {
+		fmt.Println("Not AWS access key defined")
+		return
+	}
+
+	var secretKey string
+	if secretKey, ok = os.LookupEnv("AWS_SECRET_KEY"); !ok {
+		fmt.Println("Not AWS secret key defined")
+		return
+	}
+
 	region := []string{"eu-*"}
 
 	c, err := raws.NewAWSReader(accessKey, secretKey, region, nil)
@@ -89,6 +101,7 @@ func main() {
 		fmt.Printf("Error while getting NewConnector: %s\n", err.Error())
 		return
 	}
+
 	callEC2(c)
 	callELB(c)
 	callELBv2(c)


### PR DESCRIPTION
### Abstract

Make the example/main source a non-runnable Example function, however
the content can be used to become a main function which can run.

It cannot be a runnable Example function because the messages write in
the stdout are unpredictable.

### Metadata

closes #4