### PR TITLE
Refactor error message to be meaningful

### DIFF
--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@ package raws
 
 import (
 	"fmt"
+	"strings"
 )
 
 // Interface defining an API error, this is handy as the region and service are saved
@@ -27,19 +28,26 @@ func NewAPIError(region string, service string, e error) Err {
 	}
 }
 
-// Error rerturns a string which summarize how many errors happened, in which regions and for which services.
+// Error returns a string which summarize how many errors happened and for
+// each error, the region, the service and  the error message reported by
+// AWS original error.
 func (e Errs) Error() string {
-	var output [][]string
+	if len(e) == 0 {
+		return ""
+	}
+
+	var details []string
 
 	for _, err := range e {
-		output = append(output, []string{err.Region(), err.Service()})
+		details = append(details, err.Error())
 	}
-	return fmt.Sprintf("%d error(s) occured: %s", len(e), output)
+
+	return fmt.Sprintf("%d error(s) occurred.\n\t%s", len(e), strings.Join(details, "\n\t"))
 }
 
 // Error returns a string containing the region, service as well as the original API error message.
 func (e *callErr) Error() string {
-	return fmt.Sprintf("%s: error while using '%s' service - %s",
+	return fmt.Sprintf("region: %s, service: %s, Error message: %q",
 		e.region,
 		e.service,
 		e.err.Error())

--- a/error_test.go
+++ b/error_test.go
@@ -12,7 +12,7 @@ func TestErrs_Error(t *testing.T) {
 		expectedOutput string
 	}{{name: "empty error",
 		input:          Errs{},
-		expectedOutput: "0 error(s) occured: []",
+		expectedOutput: "",
 	},
 		{name: "one error",
 			input: Errs{
@@ -22,7 +22,8 @@ func TestErrs_Error(t *testing.T) {
 					service: "service-1",
 				},
 			},
-			expectedOutput: "1 error(s) occured: [[region-1 service-1]]",
+			expectedOutput: "1 error(s) occurred.\n\t" +
+				`region: region-1, service: service-1, Error message: "fail-1"`,
 		},
 		{name: "two errors",
 			input: Errs{
@@ -37,7 +38,9 @@ func TestErrs_Error(t *testing.T) {
 					service: "service-2",
 				},
 			},
-			expectedOutput: "2 error(s) occured: [[region-1 service-1] [region-2 service-2]]",
+			expectedOutput: "2 error(s) occurred.\n\t" +
+				"region: region-1, service: service-1, Error message: \"fail-1\"\n\t" +
+				`region: region-2, service: service-2, Error message: "fail-2"`,
 		}}
 
 	for i, tt := range tests {
@@ -60,7 +63,7 @@ func TestCallErr_Error(t *testing.T) {
 			region:  "region-1",
 			service: "service-1",
 		},
-		expectedOutput: "region-1: error while using 'service-1' service - fail-1",
+		expectedOutput: `region: region-1, service: service-1, Error message: "fail-1"`,
 	},
 		{name: "another error",
 			input: callErr{
@@ -68,7 +71,7 @@ func TestCallErr_Error(t *testing.T) {
 				region:  "region-2",
 				service: "service-2",
 			},
-			expectedOutput: "region-2: error while using 'service-2' service - fail-2",
+			expectedOutput: `region: region-2, service: service-2, Error message: "fail-2"`,
 		}}
 
 	for i, tt := range tests {


### PR DESCRIPTION
Refactoring of the error message of the Err type, which is used to
return the errors of the AWSReader interface, in order to provide meaningful
details of the errors which have happened.

closes #10