### PR TITLE
CI: Update configuration not to run Go tip version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 sudo: false
 go:
  - 1.9.3
- - tip
 
 before_install:
  - go get -v github.com/mattn/goveralls


### PR DESCRIPTION
Update the configuration of the CI (travis) for not running the checks
against the Golang tip version.

Closes #14