### PR TITLE
CI: Update config to use the last Go 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: go
 sudo: false
 go:
- - 1.8.1
+ - 1.9.3
  - tip
 
 before_install:
  - go get -v github.com/mattn/goveralls
 
 install:
- - make get-deps 
+ - make get-deps
 
 script:
  - make travis-ci


### PR DESCRIPTION
Update the CI (travis) configuration to use the last Go stable version,
at the moment of this PR, which is the 1.9.3.


Closes #15

From now on, we'll create an issue/PR to do the update CI when a new Go stable release be released.