### PR TITLE
Add short notice that the library is under development

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Currently only a couple of the most used information is gathered, but adding ext
 
 Any contributions are welcome!
 
+**IMPORTANT** we are still experimenting the usage of this library, hence the public interface isn't stable as we have to see that the methods signatures fulfill the main goal of the library which is to simplify the AWS SDK to gather information. Because of this, the repo contains tags which define each version using [Semantic Versioning convention](https://semver.org/).
+
 ## Getting started
 
 ### Import the library


### PR DESCRIPTION
Add a short notice in the README to announce that the library is under
development.

Because [we have made broken changes](https://github.com/cycloidio/raws/issues/17) and there are other proposals which are breaking changes(#12 #16) for the exported interface ([AWSReader](https://github.com/cycloidio/raws/blob/master/connector.go#L32)), I think that's good to have this short notice in the README