### PR TITLE
Change AWSReader methods to return maps rather than slices

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -60,8 +60,9 @@ type AWSReader interface {
 	// Returned values are commented in the interface doc comment block.
 	GetVpcs(ctx context.Context, input *ec2.DescribeVpcsInput) (map[string]ec2.DescribeVpcsOutput, error)
 
-	// GetImages returns all EC2 AMI belonging to the Account ID based on the input given
-	GetImages(ctx context.Context, input *ec2.DescribeImagesInput) ([]*ec2.DescribeImagesOutput, error)
+	// GetImages returns all EC2 AMI belonging to the Account ID based on the input given.
+	// Returned values are commented in the interface doc comment block.
+	GetImages(ctx context.Context, input *ec2.DescribeImagesInput) (map[string]ec2.DescribeImagesOutput, error)
 
 	// GetSecurityGroups returns all EC2 security groups based on the input given
 	GetSecurityGroups(

--- a/connector.go
+++ b/connector.go
@@ -100,8 +100,9 @@ type AWSReader interface {
 		ctx context.Context, input *elb.DescribeLoadBalancersInput,
 	) (map[string]elb.DescribeLoadBalancersOutput, error)
 
-	// GetLoadBalancersTags returns a list of Tags based on the input from the different regions
-	GetLoadBalancersTags(ctx context.Context, input *elb.DescribeTagsInput) ([]*elb.DescribeTagsOutput, error)
+	// GetLoadBalancersTags returns a list of Tags based on the input from the different regions.
+	// Returned values are commented in the interface doc comment block.
+	GetLoadBalancersTags(ctx context.Context, input *elb.DescribeTagsInput) (map[string]elb.DescribeTagsOutput, error)
 
 	// GetLoadBalancersV2 returns a list of ELB (v2) - also known as ALB - based on the input from the different regions
 	GetLoadBalancersV2(

--- a/connector.go
+++ b/connector.go
@@ -145,8 +145,9 @@ type AWSReader interface {
 		ctx context.Context, w io.WriterAt, input *s3.GetObjectInput, options ...func(*s3manager.Downloader),
 	) (int64, error)
 
-	// GetObjectsTags returns tags associated with S3 objects based on the input given
-	GetObjectsTags(ctx context.Context, input *s3.GetObjectTaggingInput) ([]*s3.GetObjectTaggingOutput, error)
+	// GetObjectsTags returns tags associated with S3 objects based on the input given.
+	// Returned values are commented in the interface doc comment block.
+	GetObjectsTags(ctx context.Context, input *s3.GetObjectTaggingInput) (map[string]s3.GetObjectTaggingOutput, error)
 }
 
 // NewAWSReader returns an object which also contains the accountID and extend the different regions to use.

--- a/connector.go
+++ b/connector.go
@@ -70,8 +70,9 @@ type AWSReader interface {
 		ctx context.Context, input *ec2.DescribeSecurityGroupsInput,
 	) (map[string]ec2.DescribeSecurityGroupsOutput, error)
 
-	// GetSubnets returns all EC2 subnets based on the input given
-	GetSubnets(ctx context.Context, input *ec2.DescribeSubnetsInput) ([]*ec2.DescribeSubnetsOutput, error)
+	// GetSubnets returns all EC2 subnets based on the input given.
+	// Returned values are commented in the interface doc comment block.
+	GetSubnets(ctx context.Context, input *ec2.DescribeSubnetsInput) (map[string]ec2.DescribeSubnetsOutput, error)
 
 	// GetVolumes returns all EC2 volumes based on the input given
 	GetVolumes(ctx context.Context, input *ec2.DescribeVolumesInput) ([]*ec2.DescribeVolumesOutput, error)

--- a/connector.go
+++ b/connector.go
@@ -132,8 +132,9 @@ type AWSReader interface {
 	// Returned values are commented in the interface doc comment block.
 	ListBuckets(ctx context.Context, input *s3.ListBucketsInput) (map[string]s3.ListBucketsOutput, error)
 
-	// GetBucketTags returns tags associated with S3 buckets based on the input given
-	GetBucketTags(ctx context.Context, input *s3.GetBucketTaggingInput) ([]*s3.GetBucketTaggingOutput, error)
+	// GetBucketTags returns tags associated with S3 buckets based on the input given.
+	// Returned values are commented in the interface doc comment block.
+	GetBucketTags(ctx context.Context, input *s3.GetBucketTaggingInput) (map[string]s3.GetBucketTaggingOutput, error)
 
 	// ListObjects returns a list of all S3 objects in a bucket based on the input given
 	ListObjects(ctx context.Context, input *s3.ListObjectsInput) ([]*s3.ListObjectsOutput, error)

--- a/connector.go
+++ b/connector.go
@@ -136,8 +136,9 @@ type AWSReader interface {
 	// Returned values are commented in the interface doc comment block.
 	GetBucketTags(ctx context.Context, input *s3.GetBucketTaggingInput) (map[string]s3.GetBucketTaggingOutput, error)
 
-	// ListObjects returns a list of all S3 objects in a bucket based on the input given
-	ListObjects(ctx context.Context, input *s3.ListObjectsInput) ([]*s3.ListObjectsOutput, error)
+	// ListObjects returns a list of all S3 objects in a bucket based on the input given.
+	// Returned values are commented in the interface doc comment block.
+	ListObjects(ctx context.Context, input *s3.ListObjectsInput) (map[string]s3.ListObjectsOutput, error)
 
 	// DownloadObject downloads an object in a bucket based on the input given
 	DownloadObject(

--- a/connector.go
+++ b/connector.go
@@ -82,10 +82,11 @@ type AWSReader interface {
 	// Returned values are commented in the interface doc comment block.
 	GetSnapshots(ctx context.Context, input *ec2.DescribeSnapshotsInput) (map[string]ec2.DescribeSnapshotsOutput, error)
 
-	// GetElastiCacheCluster returns all Elasticache clusters based on the input given
+	// GetElastiCacheCluster returns all Elasticache clusters based on the input given.
+	// Returned values are commented in the interface doc comment block.
 	GetElastiCacheCluster(
 		ctx context.Context, input *elasticache.DescribeCacheClustersInput,
-	) ([]*elasticache.DescribeCacheClustersOutput, error)
+	) (map[string]elasticache.DescribeCacheClustersOutput, error)
 
 	// GetElastiCacheTags returns a list of tags of Elasticache resources based on its ARN
 	GetElastiCacheTags(

--- a/connector.go
+++ b/connector.go
@@ -128,8 +128,9 @@ type AWSReader interface {
 		ctx context.Context, input *rds.ListTagsForResourceInput,
 	) (map[string]rds.ListTagsForResourceOutput, error)
 
-	// ListBuckets returns all S3 buckets based on the input given
-	ListBuckets(ctx context.Context, input *s3.ListBucketsInput) ([]*s3.ListBucketsOutput, error)
+	// ListBuckets returns all S3 buckets based on the input given.
+	// Returned values are commented in the interface doc comment block.
+	ListBuckets(ctx context.Context, input *s3.ListBucketsInput) (map[string]s3.ListBucketsOutput, error)
 
 	// GetBucketTags returns tags associated with S3 buckets based on the input given
 	GetBucketTags(ctx context.Context, input *s3.GetBucketTaggingInput) ([]*s3.GetBucketTaggingOutput, error)

--- a/connector.go
+++ b/connector.go
@@ -122,8 +122,11 @@ type AWSReader interface {
 		ctx context.Context, input *rds.DescribeDBInstancesInput,
 	) (map[string]rds.DescribeDBInstancesOutput, error)
 
-	// GetDBInstancesTags returns a list of tags from an ARN, extra filters for tags can also be provided
-	GetDBInstancesTags(ctx context.Context, input *rds.ListTagsForResourceInput) ([]*rds.ListTagsForResourceOutput, error)
+	// GetDBInstancesTags returns a list of tags from an ARN, extra filters for tags can also be provided.
+	// Returned values are commented in the interface doc comment block.
+	GetDBInstancesTags(
+		ctx context.Context, input *rds.ListTagsForResourceInput,
+	) (map[string]rds.ListTagsForResourceOutput, error)
 
 	// ListBuckets returns all S3 buckets based on the input given
 	ListBuckets(ctx context.Context, input *s3.ListBucketsInput) ([]*s3.ListBucketsOutput, error)

--- a/connector.go
+++ b/connector.go
@@ -113,19 +113,6 @@ type AWSReader interface {
 	GetObjectsTags(ctx context.Context, input *s3.GetObjectTaggingInput) ([]*s3.GetObjectTaggingOutput, error)
 }
 
-// The connector provides easy access to AWS SDK calls.
-//
-// By using it, calls can be made directly through multiple regions, and will filter only data that belongs to you.
-// For example, when fetching the list of AMI, or snapshots.
-//
-// In order to start making calls, only calling NewAWSReader is required.
-type connector struct {
-	regions   []string
-	svcs      []*serviceConnector
-	creds     *credentials.Credentials
-	accountID *string
-}
-
 // NewAWSReader returns an object which also contains the accountID and extend the different regions to use.
 //
 // The accountID is helpful to return only the AMI or snapshots that belong to the account.
@@ -156,6 +143,19 @@ func NewAWSReader(
 	}
 	c.setServices(config)
 	return &c, nil
+}
+
+// The connector provides easy access to AWS SDK calls.
+//
+// By using it, calls can be made directly through multiple regions, and will filter only data that belongs to you.
+// For example, when fetching the list of AMI, or snapshots.
+//
+// In order to start making calls, only calling NewAWSReader is required.
+type connector struct {
+	regions   []string
+	svcs      []*serviceConnector
+	creds     *credentials.Credentials
+	accountID *string
 }
 
 func (c *connector) GetAccountID() string {

--- a/connector.go
+++ b/connector.go
@@ -74,8 +74,9 @@ type AWSReader interface {
 	// Returned values are commented in the interface doc comment block.
 	GetSubnets(ctx context.Context, input *ec2.DescribeSubnetsInput) (map[string]ec2.DescribeSubnetsOutput, error)
 
-	// GetVolumes returns all EC2 volumes based on the input given
-	GetVolumes(ctx context.Context, input *ec2.DescribeVolumesInput) ([]*ec2.DescribeVolumesOutput, error)
+	// GetVolumes returns all EC2 volumes based on the input given.
+	// Returned values are commented in the interface doc comment block.
+	GetVolumes(ctx context.Context, input *ec2.DescribeVolumesInput) (map[string]ec2.DescribeVolumesOutput, error)
 
 	// GetSnapshots returns all snapshots belonging to the Account ID based on the input given
 	GetSnapshots(ctx context.Context, input *ec2.DescribeSnapshotsInput) ([]*ec2.DescribeSnapshotsOutput, error)

--- a/connector.go
+++ b/connector.go
@@ -64,10 +64,11 @@ type AWSReader interface {
 	// Returned values are commented in the interface doc comment block.
 	GetImages(ctx context.Context, input *ec2.DescribeImagesInput) (map[string]ec2.DescribeImagesOutput, error)
 
-	// GetSecurityGroups returns all EC2 security groups based on the input given
+	// GetSecurityGroups returns all EC2 security groups based on the input given.
+	// Returned values are commented in the interface doc comment block.
 	GetSecurityGroups(
 		ctx context.Context, input *ec2.DescribeSecurityGroupsInput,
-	) ([]*ec2.DescribeSecurityGroupsOutput, error)
+	) (map[string]ec2.DescribeSecurityGroupsOutput, error)
 
 	// GetSubnets returns all EC2 subnets based on the input given
 	GetSubnets(ctx context.Context, input *ec2.DescribeSubnetsInput) ([]*ec2.DescribeSubnetsOutput, error)

--- a/connector.go
+++ b/connector.go
@@ -116,10 +116,11 @@ type AWSReader interface {
 		ctx context.Context, input *elbv2.DescribeTagsInput,
 	) (map[string]elbv2.DescribeTagsOutput, error)
 
-	// GetDBInstances returns all DB instances based on the input given
+	// GetDBInstances returns all DB instances based on the input given.
+	// Returned values are commented in the interface doc comment block.
 	GetDBInstances(
 		ctx context.Context, input *rds.DescribeDBInstancesInput,
-	) ([]*rds.DescribeDBInstancesOutput, error)
+	) (map[string]rds.DescribeDBInstancesOutput, error)
 
 	// GetDBInstancesTags returns a list of tags from an ARN, extra filters for tags can also be provided
 	GetDBInstancesTags(ctx context.Context, input *rds.ListTagsForResourceInput) ([]*rds.ListTagsForResourceOutput, error)

--- a/connector.go
+++ b/connector.go
@@ -29,6 +29,22 @@ import (
 )
 
 // AWSReader is the interface defining all methods that need to be implemented
+//
+// The next behavior commented in the below paragraph, applies to every method
+// which clearly match what's explained, for the sake of not repeating the same,
+// over and over.
+// The most of the methods defined by this interface, return their results in a
+// map. Those maps, have as keys, the AWS region which have been requested and
+// the values are the items returned by AWS for such region.
+// Because the methods may make calls to different regions, in case that there
+// is an error on a region, the returned map won't have any entry for such
+// region and such errors will be reported by the returned error, nonetheless
+// the items, got from the successful requests to other regions, will be
+// returned, with the meaning that the methods will return partial results, in
+// case of errors.
+// For avoiding by the callers the problem of if the returned map may be nil,
+// the function will always return a map instance, which will be of length 0
+// in case that there is not any successful request.
 type AWSReader interface {
 	// GetAccountID returns the current ID for the account used
 	GetAccountID() string
@@ -36,8 +52,9 @@ type AWSReader interface {
 	// GetRegions returns the currently used regions for the Connector
 	GetRegions() []string
 
-	// GetInstances returns all EC2 instances based on the input given
-	GetInstances(ctx context.Context, input *ec2.DescribeInstancesInput) ([]*ec2.DescribeInstancesOutput, error)
+	// GetInstances returns all EC2 instances based on the input given.
+	// Returned values are commented in the interface doc comment block.
+	GetInstances(ctx context.Context, input *ec2.DescribeInstancesInput) (map[string]ec2.DescribeInstancesOutput, error)
 
 	// GetVpcs returns all EC2 VPCs based on the input given
 	GetVpcs(ctx context.Context, input *ec2.DescribeVpcsInput) ([]*ec2.DescribeVpcsOutput, error)

--- a/connector.go
+++ b/connector.go
@@ -88,10 +88,11 @@ type AWSReader interface {
 		ctx context.Context, input *elasticache.DescribeCacheClustersInput,
 	) (map[string]elasticache.DescribeCacheClustersOutput, error)
 
-	// GetElastiCacheTags returns a list of tags of Elasticache resources based on its ARN
+	// GetElastiCacheTags returns a list of tags of Elasticache resources based on its ARN.
+	// Returned values are commented in the interface doc comment block.
 	GetElastiCacheTags(
 		ctx context.Context, input *elasticache.ListTagsForResourceInput,
-	) ([]*elasticache.TagListMessage, error)
+	) (map[string]elasticache.TagListMessage, error)
 
 	// GetLoadBalancers returns a list of ELB (v1) based on the input from the different regions
 	GetLoadBalancers(

--- a/connector.go
+++ b/connector.go
@@ -78,8 +78,9 @@ type AWSReader interface {
 	// Returned values are commented in the interface doc comment block.
 	GetVolumes(ctx context.Context, input *ec2.DescribeVolumesInput) (map[string]ec2.DescribeVolumesOutput, error)
 
-	// GetSnapshots returns all snapshots belonging to the Account ID based on the input given
-	GetSnapshots(ctx context.Context, input *ec2.DescribeSnapshotsInput) ([]*ec2.DescribeSnapshotsOutput, error)
+	// GetSnapshots returns all snapshots belonging to the Account ID based on the input given.
+	// Returned values are commented in the interface doc comment block.
+	GetSnapshots(ctx context.Context, input *ec2.DescribeSnapshotsInput) (map[string]ec2.DescribeSnapshotsOutput, error)
 
 	// GetElastiCacheCluster returns all Elasticache clusters based on the input given
 	GetElastiCacheCluster(

--- a/connector.go
+++ b/connector.go
@@ -94,10 +94,11 @@ type AWSReader interface {
 		ctx context.Context, input *elasticache.ListTagsForResourceInput,
 	) (map[string]elasticache.TagListMessage, error)
 
-	// GetLoadBalancers returns a list of ELB (v1) based on the input from the different regions
+	// GetLoadBalancers returns a list of ELB (v1) based on the input from the different regions.
+	// Returned values are commented in the interface doc comment block.
 	GetLoadBalancers(
 		ctx context.Context, input *elb.DescribeLoadBalancersInput,
-	) ([]*elb.DescribeLoadBalancersOutput, error)
+	) (map[string]elb.DescribeLoadBalancersOutput, error)
 
 	// GetLoadBalancersTags returns a list of Tags based on the input from the different regions
 	GetLoadBalancersTags(ctx context.Context, input *elb.DescribeTagsInput) ([]*elb.DescribeTagsOutput, error)

--- a/connector.go
+++ b/connector.go
@@ -56,8 +56,9 @@ type AWSReader interface {
 	// Returned values are commented in the interface doc comment block.
 	GetInstances(ctx context.Context, input *ec2.DescribeInstancesInput) (map[string]ec2.DescribeInstancesOutput, error)
 
-	// GetVpcs returns all EC2 VPCs based on the input given
-	GetVpcs(ctx context.Context, input *ec2.DescribeVpcsInput) ([]*ec2.DescribeVpcsOutput, error)
+	// GetVpcs returns all EC2 VPCs based on the input given.
+	// Returned values are commented in the interface doc comment block.
+	GetVpcs(ctx context.Context, input *ec2.DescribeVpcsInput) (map[string]ec2.DescribeVpcsOutput, error)
 
 	// GetImages returns all EC2 AMI belonging to the Account ID based on the input given
 	GetImages(ctx context.Context, input *ec2.DescribeImagesInput) ([]*ec2.DescribeImagesOutput, error)

--- a/connector.go
+++ b/connector.go
@@ -104,10 +104,11 @@ type AWSReader interface {
 	// Returned values are commented in the interface doc comment block.
 	GetLoadBalancersTags(ctx context.Context, input *elb.DescribeTagsInput) (map[string]elb.DescribeTagsOutput, error)
 
-	// GetLoadBalancersV2 returns a list of ELB (v2) - also known as ALB - based on the input from the different regions
+	// GetLoadBalancersV2 returns a list of ELB (v2) - also known as ALB - based on the input from the different regions.
+	// Returned values are commented in the interface doc comment block.
 	GetLoadBalancersV2(
 		ctx context.Context, input *elbv2.DescribeLoadBalancersInput,
-	) ([]*elbv2.DescribeLoadBalancersOutput, error)
+	) (map[string]elbv2.DescribeLoadBalancersOutput, error)
 
 	// GetLoadBalancersV2Tags returns a list of Tags based on the input from the different regions
 	GetLoadBalancersV2Tags(

--- a/connector.go
+++ b/connector.go
@@ -110,10 +110,11 @@ type AWSReader interface {
 		ctx context.Context, input *elbv2.DescribeLoadBalancersInput,
 	) (map[string]elbv2.DescribeLoadBalancersOutput, error)
 
-	// GetLoadBalancersV2Tags returns a list of Tags based on the input from the different regions
+	// GetLoadBalancersV2Tags returns a list of Tags based on the input from the different regions.
+	// Returned values are commented in the interface doc comment block.
 	GetLoadBalancersV2Tags(
 		ctx context.Context, input *elbv2.DescribeTagsInput,
-	) ([]*elbv2.DescribeTagsOutput, error)
+	) (map[string]elbv2.DescribeTagsOutput, error)
 
 	// GetDBInstances returns all DB instances based on the input given
 	GetDBInstances(

--- a/ec2.go
+++ b/ec2.go
@@ -58,9 +58,9 @@ func (c *connector) GetVpcs(
 
 func (c *connector) GetImages(
 	ctx context.Context, input *ec2.DescribeImagesInput,
-) ([]*ec2.DescribeImagesOutput, error) {
+) (map[string]ec2.DescribeImagesOutput, error) {
 	var errs Errors
-	var images []*ec2.DescribeImagesOutput
+	var images = map[string]ec2.DescribeImagesOutput{}
 
 	if input == nil {
 		input = &ec2.DescribeImagesInput{}
@@ -74,7 +74,7 @@ func (c *connector) GetImages(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, ec2.ServiceName, err))
 		} else {
-			images = append(images, image)
+			images[svc.region] = *image
 		}
 	}
 

--- a/ec2.go
+++ b/ec2.go
@@ -8,9 +8,9 @@ import (
 
 func (c *connector) GetInstances(
 	ctx context.Context, input *ec2.DescribeInstancesInput,
-) ([]*ec2.DescribeInstancesOutput, error) {
+) (map[string]ec2.DescribeInstancesOutput, error) {
 	var errs Errors
-	var instances []*ec2.DescribeInstancesOutput
+	var instances = map[string]ec2.DescribeInstancesOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.ec2 == nil {
@@ -20,7 +20,7 @@ func (c *connector) GetInstances(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, ec2.ServiceName, err))
 		} else {
-			instances = append(instances, instance)
+			instances[svc.region] = *instance
 		}
 	}
 

--- a/ec2.go
+++ b/ec2.go
@@ -137,9 +137,9 @@ func (c *connector) GetSubnets(
 
 func (c *connector) GetVolumes(
 	ctx context.Context, input *ec2.DescribeVolumesInput,
-) ([]*ec2.DescribeVolumesOutput, error) {
+) (map[string]ec2.DescribeVolumesOutput, error) {
 	var errs Errors
-	var volumes []*ec2.DescribeVolumesOutput
+	var volumes = map[string]ec2.DescribeVolumesOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.ec2 == nil {
@@ -149,7 +149,7 @@ func (c *connector) GetVolumes(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, ec2.ServiceName, err))
 		} else {
-			volumes = append(volumes, volume)
+			volumes[svc.region] = *volume
 		}
 	}
 

--- a/ec2.go
+++ b/ec2.go
@@ -87,9 +87,9 @@ func (c *connector) GetImages(
 
 func (c *connector) GetSecurityGroups(
 	ctx context.Context, input *ec2.DescribeSecurityGroupsInput,
-) ([]*ec2.DescribeSecurityGroupsOutput, error) {
+) (map[string]ec2.DescribeSecurityGroupsOutput, error) {
 	var errs Errors
-	var secgroups []*ec2.DescribeSecurityGroupsOutput
+	var secgroups = map[string]ec2.DescribeSecurityGroupsOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.ec2 == nil {
@@ -99,7 +99,7 @@ func (c *connector) GetSecurityGroups(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, ec2.ServiceName, err))
 		} else {
-			secgroups = append(secgroups, secgroup)
+			secgroups[svc.region] = *secgroup
 		}
 	}
 

--- a/ec2.go
+++ b/ec2.go
@@ -112,9 +112,9 @@ func (c *connector) GetSecurityGroups(
 
 func (c *connector) GetSubnets(
 	ctx context.Context, input *ec2.DescribeSubnetsInput,
-) ([]*ec2.DescribeSubnetsOutput, error) {
+) (map[string]ec2.DescribeSubnetsOutput, error) {
 	var errs Errors
-	var subnets []*ec2.DescribeSubnetsOutput
+	var subnets = map[string]ec2.DescribeSubnetsOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.ec2 == nil {
@@ -124,7 +124,7 @@ func (c *connector) GetSubnets(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, ec2.ServiceName, err))
 		} else {
-			subnets = append(subnets, subnet)
+			subnets[svc.region] = *subnet
 		}
 	}
 

--- a/ec2.go
+++ b/ec2.go
@@ -162,9 +162,9 @@ func (c *connector) GetVolumes(
 
 func (c *connector) GetSnapshots(
 	ctx context.Context, input *ec2.DescribeSnapshotsInput,
-) ([]*ec2.DescribeSnapshotsOutput, error) {
+) (map[string]ec2.DescribeSnapshotsOutput, error) {
 	var errs Errors
-	var snapshots []*ec2.DescribeSnapshotsOutput
+	var snapshots = map[string]ec2.DescribeSnapshotsOutput{}
 
 	if input == nil {
 		input = &ec2.DescribeSnapshotsInput{}
@@ -178,7 +178,7 @@ func (c *connector) GetSnapshots(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, ec2.ServiceName, err))
 		} else {
-			snapshots = append(snapshots, snapshot)
+			snapshots[svc.region] = *snapshot
 		}
 	}
 

--- a/ec2.go
+++ b/ec2.go
@@ -31,9 +31,11 @@ func (c *connector) GetInstances(
 	return instances, nil
 }
 
-func (c *connector) GetVpcs(ctx context.Context, input *ec2.DescribeVpcsInput) ([]*ec2.DescribeVpcsOutput, error) {
+func (c *connector) GetVpcs(
+	ctx context.Context, input *ec2.DescribeVpcsInput,
+) (map[string]ec2.DescribeVpcsOutput, error) {
 	var errs Errors
-	var vpcs []*ec2.DescribeVpcsOutput
+	var vpcs = map[string]ec2.DescribeVpcsOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.ec2 == nil {
@@ -43,7 +45,7 @@ func (c *connector) GetVpcs(ctx context.Context, input *ec2.DescribeVpcsInput) (
 		if err != nil {
 			errs = append(errs, NewError(svc.region, ec2.ServiceName, err))
 		} else {
-			vpcs = append(vpcs, vpc)
+			vpcs[svc.region] = *vpc
 		}
 	}
 

--- a/ec2_test.go
+++ b/ec2_test.go
@@ -763,7 +763,7 @@ func TestGetVolumes(t *testing.T) {
 	tests := []struct {
 		name            string
 		mocked          []*serviceConnector
-		expectedVolumes []*ec2.DescribeVolumesOutput
+		expectedVolumes map[string]ec2.DescribeVolumesOutput
 		expectedError   error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -780,7 +780,7 @@ func TestGetVolumes(t *testing.T) {
 			region:  "test",
 			service: ec2.ServiceName,
 		}},
-		expectedVolumes: nil,
+		expectedVolumes: map[string]ec2.DescribeVolumesOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -797,8 +797,8 @@ func TestGetVolumes(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedVolumes: []*ec2.DescribeVolumesOutput{
-				{
+			expectedVolumes: map[string]ec2.DescribeVolumesOutput{
+				"test": {
 					Volumes: []*ec2.Volume{{
 						VolumeId: aws.String("1"),
 					}},
@@ -831,13 +831,13 @@ func TestGetVolumes(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedVolumes: []*ec2.DescribeVolumesOutput{
-				{
+			expectedVolumes: map[string]ec2.DescribeVolumesOutput{
+				"test-1": {
 					Volumes: []*ec2.Volume{{
 						VolumeId: aws.String("1"),
 					}},
 				},
-				{
+				"test-2": {
 					Volumes: []*ec2.Volume{{
 						VolumeId: aws.String("2"),
 					}},
@@ -870,8 +870,8 @@ func TestGetVolumes(t *testing.T) {
 				region:  "test-1",
 				service: ec2.ServiceName,
 			}},
-			expectedVolumes: []*ec2.DescribeVolumesOutput{
-				{
+			expectedVolumes: map[string]ec2.DescribeVolumesOutput{
+				"test-2": {
 					Volumes: []*ec2.Volume{{
 						VolumeId: aws.String("2"),
 					}},

--- a/ec2_test.go
+++ b/ec2_test.go
@@ -631,7 +631,7 @@ func TestGetSubnets(t *testing.T) {
 	tests := []struct {
 		name            string
 		mocked          []*serviceConnector
-		expectedSubnets []*ec2.DescribeSubnetsOutput
+		expectedSubnets map[string]ec2.DescribeSubnetsOutput
 		expectedError   error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -648,7 +648,7 @@ func TestGetSubnets(t *testing.T) {
 			region:  "test",
 			service: ec2.ServiceName,
 		}},
-		expectedSubnets: nil,
+		expectedSubnets: map[string]ec2.DescribeSubnetsOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -665,8 +665,8 @@ func TestGetSubnets(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedSubnets: []*ec2.DescribeSubnetsOutput{
-				{
+			expectedSubnets: map[string]ec2.DescribeSubnetsOutput{
+				"test": {
 					Subnets: []*ec2.Subnet{{
 						SubnetId: aws.String("1"),
 					}},
@@ -699,13 +699,13 @@ func TestGetSubnets(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedSubnets: []*ec2.DescribeSubnetsOutput{
-				{
+			expectedSubnets: map[string]ec2.DescribeSubnetsOutput{
+				"test-1": {
 					Subnets: []*ec2.Subnet{{
 						SubnetId: aws.String("1"),
 					}},
 				},
-				{
+				"test-2": {
 					Subnets: []*ec2.Subnet{{
 						SubnetId: aws.String("2"),
 					}},
@@ -738,8 +738,8 @@ func TestGetSubnets(t *testing.T) {
 				region:  "test-1",
 				service: ec2.ServiceName,
 			}},
-			expectedSubnets: []*ec2.DescribeSubnetsOutput{
-				{
+			expectedSubnets: map[string]ec2.DescribeSubnetsOutput{
+				"test-2": {
 					Subnets: []*ec2.Subnet{{
 						SubnetId: aws.String("2"),
 					}},

--- a/ec2_test.go
+++ b/ec2_test.go
@@ -99,7 +99,7 @@ func TestGetInstances(t *testing.T) {
 	tests := []struct {
 		name              string
 		mocked            []*serviceConnector
-		expectedInstances []*ec2.DescribeInstancesOutput
+		expectedInstances map[string]ec2.DescribeInstancesOutput
 		expectedError     error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -116,7 +116,7 @@ func TestGetInstances(t *testing.T) {
 			region:  "test",
 			service: ec2.ServiceName,
 		}},
-		expectedInstances: nil,
+		expectedInstances: map[string]ec2.DescribeInstancesOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -133,8 +133,8 @@ func TestGetInstances(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedInstances: []*ec2.DescribeInstancesOutput{
-				{
+			expectedInstances: map[string]ec2.DescribeInstancesOutput{
+				"test": {
 					Reservations: []*ec2.Reservation{{
 						OwnerId: aws.String("xxx"),
 					}},
@@ -167,13 +167,13 @@ func TestGetInstances(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedInstances: []*ec2.DescribeInstancesOutput{
-				{
+			expectedInstances: map[string]ec2.DescribeInstancesOutput{
+				"test-1": {
 					Reservations: []*ec2.Reservation{{
 						OwnerId: aws.String("xxx"),
 					}},
 				},
-				{
+				"test-2": {
 					Reservations: []*ec2.Reservation{{
 						OwnerId: aws.String("yyy"),
 					}},
@@ -206,8 +206,8 @@ func TestGetInstances(t *testing.T) {
 				region:  "test-1",
 				service: ec2.ServiceName,
 			}},
-			expectedInstances: []*ec2.DescribeInstancesOutput{
-				{
+			expectedInstances: map[string]ec2.DescribeInstancesOutput{
+				"test-2": {
 					Reservations: []*ec2.Reservation{{
 						OwnerId: aws.String("yyy"),
 					}},

--- a/ec2_test.go
+++ b/ec2_test.go
@@ -896,7 +896,7 @@ func TestGetSnapshots(t *testing.T) {
 	tests := []struct {
 		name              string
 		mocked            []*serviceConnector
-		expectedSnapshots []*ec2.DescribeSnapshotsOutput
+		expectedSnapshots map[string]ec2.DescribeSnapshotsOutput
 		expectedError     error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -917,7 +917,7 @@ func TestGetSnapshots(t *testing.T) {
 			region:  "test",
 			service: ec2.ServiceName,
 		}},
-		expectedSnapshots: nil,
+		expectedSnapshots: map[string]ec2.DescribeSnapshotsOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -934,8 +934,8 @@ func TestGetSnapshots(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedSnapshots: []*ec2.DescribeSnapshotsOutput{
-				{
+			expectedSnapshots: map[string]ec2.DescribeSnapshotsOutput{
+				"test": {
 					Snapshots: []*ec2.Snapshot{{
 						SnapshotId: aws.String("1"),
 					}},
@@ -968,13 +968,13 @@ func TestGetSnapshots(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedSnapshots: []*ec2.DescribeSnapshotsOutput{
-				{
+			expectedSnapshots: map[string]ec2.DescribeSnapshotsOutput{
+				"test-1": {
 					Snapshots: []*ec2.Snapshot{{
 						SnapshotId: aws.String("1"),
 					}},
 				},
-				{
+				"test-2": {
 					Snapshots: []*ec2.Snapshot{{
 						SnapshotId: aws.String("2"),
 					}},
@@ -1007,8 +1007,8 @@ func TestGetSnapshots(t *testing.T) {
 				region:  "test-1",
 				service: ec2.ServiceName,
 			}},
-			expectedSnapshots: []*ec2.DescribeSnapshotsOutput{
-				{
+			expectedSnapshots: map[string]ec2.DescribeSnapshotsOutput{
+				"test-2": {
 					Snapshots: []*ec2.Snapshot{{
 						SnapshotId: aws.String("2"),
 					}},

--- a/ec2_test.go
+++ b/ec2_test.go
@@ -232,7 +232,7 @@ func TestGetVpcs(t *testing.T) {
 	tests := []struct {
 		name          string
 		mocked        []*serviceConnector
-		expectedVpcs  []*ec2.DescribeVpcsOutput
+		expectedVpcs  map[string]ec2.DescribeVpcsOutput
 		expectedError error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -249,7 +249,7 @@ func TestGetVpcs(t *testing.T) {
 			region:  "test",
 			service: ec2.ServiceName,
 		}},
-		expectedVpcs: nil,
+		expectedVpcs: map[string]ec2.DescribeVpcsOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -266,8 +266,8 @@ func TestGetVpcs(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedVpcs: []*ec2.DescribeVpcsOutput{
-				{
+			expectedVpcs: map[string]ec2.DescribeVpcsOutput{
+				"test": {
 					Vpcs: []*ec2.Vpc{{
 						VpcId: aws.String("1"),
 					}},
@@ -300,13 +300,13 @@ func TestGetVpcs(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedVpcs: []*ec2.DescribeVpcsOutput{
-				{
+			expectedVpcs: map[string]ec2.DescribeVpcsOutput{
+				"test-1": {
 					Vpcs: []*ec2.Vpc{{
 						VpcId: aws.String("1"),
 					}},
 				},
-				{
+				"test-2": {
 					Vpcs: []*ec2.Vpc{{
 						VpcId: aws.String("2"),
 					}},
@@ -339,8 +339,8 @@ func TestGetVpcs(t *testing.T) {
 				region:  "test-1",
 				service: ec2.ServiceName,
 			}},
-			expectedVpcs: []*ec2.DescribeVpcsOutput{
-				{
+			expectedVpcs: map[string]ec2.DescribeVpcsOutput{
+				"test-2": {
 					Vpcs: []*ec2.Vpc{{
 						VpcId: aws.String("2"),
 					}},

--- a/ec2_test.go
+++ b/ec2_test.go
@@ -498,7 +498,7 @@ func TestGetSecurityGroups(t *testing.T) {
 	tests := []struct {
 		name              string
 		mocked            []*serviceConnector
-		expectedSecGroups []*ec2.DescribeSecurityGroupsOutput
+		expectedSecGroups map[string]ec2.DescribeSecurityGroupsOutput
 		expectedError     error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -515,7 +515,7 @@ func TestGetSecurityGroups(t *testing.T) {
 			region:  "test",
 			service: ec2.ServiceName,
 		}},
-		expectedSecGroups: nil,
+		expectedSecGroups: map[string]ec2.DescribeSecurityGroupsOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -532,8 +532,8 @@ func TestGetSecurityGroups(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedSecGroups: []*ec2.DescribeSecurityGroupsOutput{
-				{
+			expectedSecGroups: map[string]ec2.DescribeSecurityGroupsOutput{
+				"test": {
 					SecurityGroups: []*ec2.SecurityGroup{{
 						GroupId: aws.String("1"),
 					}},
@@ -566,13 +566,13 @@ func TestGetSecurityGroups(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedSecGroups: []*ec2.DescribeSecurityGroupsOutput{
-				{
+			expectedSecGroups: map[string]ec2.DescribeSecurityGroupsOutput{
+				"test-1": {
 					SecurityGroups: []*ec2.SecurityGroup{{
 						GroupId: aws.String("1"),
 					}},
 				},
-				{
+				"test-2": {
 					SecurityGroups: []*ec2.SecurityGroup{{
 						GroupId: aws.String("2"),
 					}},
@@ -605,8 +605,8 @@ func TestGetSecurityGroups(t *testing.T) {
 				region:  "test-1",
 				service: ec2.ServiceName,
 			}},
-			expectedSecGroups: []*ec2.DescribeSecurityGroupsOutput{
-				{
+			expectedSecGroups: map[string]ec2.DescribeSecurityGroupsOutput{
+				"test-2": {
 					SecurityGroups: []*ec2.SecurityGroup{{
 						GroupId: aws.String("2"),
 					}},

--- a/ec2_test.go
+++ b/ec2_test.go
@@ -365,7 +365,7 @@ func TestGetImages(t *testing.T) {
 	tests := []struct {
 		name           string
 		mocked         []*serviceConnector
-		expectedImages []*ec2.DescribeImagesOutput
+		expectedImages map[string]ec2.DescribeImagesOutput
 		expectedError  error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -382,7 +382,7 @@ func TestGetImages(t *testing.T) {
 			region:  "test",
 			service: ec2.ServiceName,
 		}},
-		expectedImages: nil,
+		expectedImages: map[string]ec2.DescribeImagesOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -399,8 +399,8 @@ func TestGetImages(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedImages: []*ec2.DescribeImagesOutput{
-				{
+			expectedImages: map[string]ec2.DescribeImagesOutput{
+				"test": {
 					Images: []*ec2.Image{{
 						Name: aws.String("test"),
 					}},
@@ -433,13 +433,13 @@ func TestGetImages(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedImages: []*ec2.DescribeImagesOutput{
-				{
+			expectedImages: map[string]ec2.DescribeImagesOutput{
+				"test-1": {
 					Images: []*ec2.Image{{
 						Name: aws.String("test-1"),
 					}},
 				},
-				{
+				"test-2": {
 					Images: []*ec2.Image{{
 						Name: aws.String("test-2"),
 					}},
@@ -472,8 +472,8 @@ func TestGetImages(t *testing.T) {
 				region:  "test-1",
 				service: ec2.ServiceName,
 			}},
-			expectedImages: []*ec2.DescribeImagesOutput{
-				{
+			expectedImages: map[string]ec2.DescribeImagesOutput{
+				"test-2": {
 					Images: []*ec2.Image{{
 						Name: aws.String("test-2"),
 					}},

--- a/elasticache.go
+++ b/elasticache.go
@@ -33,9 +33,9 @@ func (c *connector) GetElastiCacheCluster(
 
 func (c *connector) GetElastiCacheTags(
 	ctx context.Context, input *elasticache.ListTagsForResourceInput,
-) ([]*elasticache.TagListMessage, error) {
+) (map[string]elasticache.TagListMessage, error) {
 	var errs Errors
-	var elastiCacheTags []*elasticache.TagListMessage
+	var elastiCacheTags = map[string]elasticache.TagListMessage{}
 
 	for _, svc := range c.svcs {
 		if svc.elasticache == nil {
@@ -45,7 +45,7 @@ func (c *connector) GetElastiCacheTags(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, elasticache.ServiceName, err))
 		} else {
-			elastiCacheTags = append(elastiCacheTags, elasticacheTag)
+			elastiCacheTags[svc.region] = *elasticacheTag
 		}
 	}
 

--- a/elasticache.go
+++ b/elasticache.go
@@ -8,9 +8,9 @@ import (
 
 func (c *connector) GetElastiCacheCluster(
 	ctx context.Context, input *elasticache.DescribeCacheClustersInput,
-) ([]*elasticache.DescribeCacheClustersOutput, error) {
+) (map[string]elasticache.DescribeCacheClustersOutput, error) {
 	var errs Errors
-	var elasticCacheClusters []*elasticache.DescribeCacheClustersOutput
+	var elasticCacheClusters = map[string]elasticache.DescribeCacheClustersOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.elasticache == nil {
@@ -20,7 +20,7 @@ func (c *connector) GetElastiCacheCluster(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, elasticache.ServiceName, err))
 		} else {
-			elasticCacheClusters = append(elasticCacheClusters, elasticCacheCluster)
+			elasticCacheClusters[svc.region] = *elasticCacheCluster
 		}
 	}
 

--- a/elasticache_test.go
+++ b/elasticache_test.go
@@ -192,7 +192,7 @@ func TestGetElastiCacheTags(t *testing.T) {
 	tests := []struct {
 		name          string
 		mocked        []*serviceConnector
-		expectedTags  []*elasticache.TagListMessage
+		expectedTags  map[string]elasticache.TagListMessage
 		expectedError error
 	}{{name: "one region no error",
 		mocked: []*serviceConnector{
@@ -211,8 +211,8 @@ func TestGetElastiCacheTags(t *testing.T) {
 			},
 		},
 		expectedError: nil,
-		expectedTags: []*elasticache.TagListMessage{
-			{
+		expectedTags: map[string]elasticache.TagListMessage{
+			"test": {
 				TagList: []*elasticache.Tag{
 					{
 						Key:   aws.String("test"),
@@ -241,7 +241,7 @@ func TestGetElastiCacheTags(t *testing.T) {
 					service: elasticache.ServiceName,
 				},
 			},
-			expectedTags: nil,
+			expectedTags: map[string]elasticache.TagListMessage{},
 		},
 		{name: "multiple region no error",
 			mocked: []*serviceConnector{
@@ -273,8 +273,8 @@ func TestGetElastiCacheTags(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedTags: []*elasticache.TagListMessage{
-				{
+			expectedTags: map[string]elasticache.TagListMessage{
+				"test-1": {
 					TagList: []*elasticache.Tag{
 						{
 							Key:   aws.String("test"),
@@ -282,7 +282,7 @@ func TestGetElastiCacheTags(t *testing.T) {
 						},
 					},
 				},
-				{
+				"test-2": {
 					TagList: []*elasticache.Tag{
 						{
 							Key:   aws.String("test"),
@@ -322,8 +322,8 @@ func TestGetElastiCacheTags(t *testing.T) {
 					service: elasticache.ServiceName,
 				},
 			},
-			expectedTags: []*elasticache.TagListMessage{
-				{
+			expectedTags: map[string]elasticache.TagListMessage{
+				"test-2": {
 					TagList: []*elasticache.Tag{
 						{
 							Key:   aws.String("test"),

--- a/elasticache_test.go
+++ b/elasticache_test.go
@@ -40,7 +40,7 @@ func TestGetElastiCacheCluster(t *testing.T) {
 	tests := []struct {
 		name             string
 		mocked           []*serviceConnector
-		expectedClusters []*elasticache.DescribeCacheClustersOutput
+		expectedClusters map[string]elasticache.DescribeCacheClustersOutput
 		expectedError    error
 	}{{name: "one region no error",
 		mocked: []*serviceConnector{
@@ -59,8 +59,8 @@ func TestGetElastiCacheCluster(t *testing.T) {
 			},
 		},
 		expectedError: nil,
-		expectedClusters: []*elasticache.DescribeCacheClustersOutput{
-			{
+		expectedClusters: map[string]elasticache.DescribeCacheClustersOutput{
+			"test": {
 				CacheClusters: []*elasticache.CacheCluster{
 					{
 						CacheClusterId: aws.String("1"),
@@ -84,7 +84,7 @@ func TestGetElastiCacheCluster(t *testing.T) {
 				region:  "test",
 				service: elasticache.ServiceName,
 			}},
-			expectedClusters: nil,
+			expectedClusters: map[string]elasticache.DescribeCacheClustersOutput{},
 		},
 		{name: "multiple region no error",
 			mocked: []*serviceConnector{
@@ -116,15 +116,15 @@ func TestGetElastiCacheCluster(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedClusters: []*elasticache.DescribeCacheClustersOutput{
-				{
+			expectedClusters: map[string]elasticache.DescribeCacheClustersOutput{
+				"test-1": {
 					CacheClusters: []*elasticache.CacheCluster{
 						{
 							CacheClusterId: aws.String("1"),
 						},
 					},
 				},
-				{
+				"test-2": {
 					CacheClusters: []*elasticache.CacheCluster{
 						{
 							CacheClusterId: aws.String("2"),
@@ -163,8 +163,8 @@ func TestGetElastiCacheCluster(t *testing.T) {
 					service: elasticache.ServiceName,
 				},
 			},
-			expectedClusters: []*elasticache.DescribeCacheClustersOutput{
-				{
+			expectedClusters: map[string]elasticache.DescribeCacheClustersOutput{
+				"test-2": {
 					CacheClusters: []*elasticache.CacheCluster{
 						{
 							CacheClusterId: aws.String("2"),

--- a/elb.go
+++ b/elb.go
@@ -8,9 +8,9 @@ import (
 
 func (c *connector) GetLoadBalancers(
 	ctx context.Context, input *elb.DescribeLoadBalancersInput,
-) ([]*elb.DescribeLoadBalancersOutput, error) {
-	var elbs []*elb.DescribeLoadBalancersOutput
+) (map[string]elb.DescribeLoadBalancersOutput, error) {
 	var errs Errors
+	var elbs = map[string]elb.DescribeLoadBalancersOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.elb == nil {
@@ -20,7 +20,7 @@ func (c *connector) GetLoadBalancers(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, elb.ServiceName, err))
 		} else {
-			elbs = append(elbs, elbv1)
+			elbs[svc.region] = *elbv1
 		}
 	}
 

--- a/elb.go
+++ b/elb.go
@@ -33,9 +33,9 @@ func (c *connector) GetLoadBalancers(
 
 func (c *connector) GetLoadBalancersTags(
 	ctx context.Context, input *elb.DescribeTagsInput,
-) ([]*elb.DescribeTagsOutput, error) {
-	var elbTags []*elb.DescribeTagsOutput
+) (map[string]elb.DescribeTagsOutput, error) {
 	var errs Errors
+	var elbTags = map[string]elb.DescribeTagsOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.elb == nil {
@@ -45,7 +45,7 @@ func (c *connector) GetLoadBalancersTags(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, elb.ServiceName, err))
 		} else {
-			elbTags = append(elbTags, tags)
+			elbTags[svc.region] = *tags
 		}
 	}
 

--- a/elb_test.go
+++ b/elb_test.go
@@ -193,7 +193,7 @@ func TestGetLoadBalancersTags(t *testing.T) {
 	tests := []struct {
 		name          string
 		mocked        []*serviceConnector
-		expectedTags  []*elb.DescribeTagsOutput
+		expectedTags  map[string]elb.DescribeTagsOutput
 		expectedError error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -210,7 +210,7 @@ func TestGetLoadBalancersTags(t *testing.T) {
 			region:  "test",
 			service: elb.ServiceName,
 		}},
-		expectedTags: nil,
+		expectedTags: map[string]elb.DescribeTagsOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -229,8 +229,8 @@ func TestGetLoadBalancersTags(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedTags: []*elb.DescribeTagsOutput{
-				{
+			expectedTags: map[string]elb.DescribeTagsOutput{
+				"test": {
 					TagDescriptions: []*elb.TagDescription{
 						{
 							LoadBalancerName: aws.String("1"),
@@ -269,15 +269,15 @@ func TestGetLoadBalancersTags(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedTags: []*elb.DescribeTagsOutput{
-				{
+			expectedTags: map[string]elb.DescribeTagsOutput{
+				"test-1": {
 					TagDescriptions: []*elb.TagDescription{
 						{
 							LoadBalancerName: aws.String("1"),
 						},
 					},
 				},
-				{
+				"test-2": {
 					TagDescriptions: []*elb.TagDescription{
 						{
 							LoadBalancerName: aws.String("2"),
@@ -316,8 +316,8 @@ func TestGetLoadBalancersTags(t *testing.T) {
 					service: elb.ServiceName,
 				},
 			},
-			expectedTags: []*elb.DescribeTagsOutput{
-				{
+			expectedTags: map[string]elb.DescribeTagsOutput{
+				"test-2": {
 					TagDescriptions: []*elb.TagDescription{
 						{
 							LoadBalancerName: aws.String("2"),

--- a/elb_test.go
+++ b/elb_test.go
@@ -41,7 +41,7 @@ func TestGetLoadBalancers(t *testing.T) {
 	tests := []struct {
 		name          string
 		mocked        []*serviceConnector
-		expectedELBs  []*elb.DescribeLoadBalancersOutput
+		expectedELBs  map[string]elb.DescribeLoadBalancersOutput
 		expectedError error
 	}{{name: "one region no error",
 		mocked: []*serviceConnector{
@@ -58,7 +58,7 @@ func TestGetLoadBalancers(t *testing.T) {
 			region:  "test",
 			service: elb.ServiceName,
 		}},
-		expectedELBs: nil,
+		expectedELBs: map[string]elb.DescribeLoadBalancersOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -77,8 +77,8 @@ func TestGetLoadBalancers(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedELBs: []*elb.DescribeLoadBalancersOutput{
-				{
+			expectedELBs: map[string]elb.DescribeLoadBalancersOutput{
+				"test": {
 					LoadBalancerDescriptions: []*elb.LoadBalancerDescription{
 						{
 							LoadBalancerName: aws.String("1"),
@@ -117,15 +117,15 @@ func TestGetLoadBalancers(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedELBs: []*elb.DescribeLoadBalancersOutput{
-				{
+			expectedELBs: map[string]elb.DescribeLoadBalancersOutput{
+				"test-1": {
 					LoadBalancerDescriptions: []*elb.LoadBalancerDescription{
 						{
 							LoadBalancerName: aws.String("1"),
 						},
 					},
 				},
-				{
+				"test-2": {
 					LoadBalancerDescriptions: []*elb.LoadBalancerDescription{
 						{
 							LoadBalancerName: aws.String("2"),
@@ -164,8 +164,8 @@ func TestGetLoadBalancers(t *testing.T) {
 					service: elb.ServiceName,
 				},
 			},
-			expectedELBs: []*elb.DescribeLoadBalancersOutput{
-				{
+			expectedELBs: map[string]elb.DescribeLoadBalancersOutput{
+				"test-2": {
 					LoadBalancerDescriptions: []*elb.LoadBalancerDescription{
 						{
 							LoadBalancerName: aws.String("2"),

--- a/elbv2.go
+++ b/elbv2.go
@@ -33,9 +33,9 @@ func (c *connector) GetLoadBalancersV2(
 
 func (c *connector) GetLoadBalancersV2Tags(
 	ctx context.Context, input *elbv2.DescribeTagsInput,
-) ([]*elbv2.DescribeTagsOutput, error) {
+) (map[string]elbv2.DescribeTagsOutput, error) {
 	var errs Errors
-	var elbTags []*elbv2.DescribeTagsOutput
+	var elbTags = map[string]elbv2.DescribeTagsOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.elbv2 == nil {
@@ -45,7 +45,7 @@ func (c *connector) GetLoadBalancersV2Tags(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, elbv2.ServiceName, err))
 		} else {
-			elbTags = append(elbTags, elbTag)
+			elbTags[svc.region] = *elbTag
 		}
 	}
 

--- a/elbv2.go
+++ b/elbv2.go
@@ -8,9 +8,9 @@ import (
 
 func (c *connector) GetLoadBalancersV2(
 	ctx context.Context, input *elbv2.DescribeLoadBalancersInput,
-) ([]*elbv2.DescribeLoadBalancersOutput, error) {
+) (map[string]elbv2.DescribeLoadBalancersOutput, error) {
 	var errs Errors
-	var elbs []*elbv2.DescribeLoadBalancersOutput
+	var elbs = map[string]elbv2.DescribeLoadBalancersOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.elbv2 == nil {
@@ -20,7 +20,7 @@ func (c *connector) GetLoadBalancersV2(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, elbv2.ServiceName, err))
 		} else {
-			elbs = append(elbs, elb)
+			elbs[svc.region] = *elb
 		}
 	}
 

--- a/elbv2_test.go
+++ b/elbv2_test.go
@@ -41,7 +41,7 @@ func TestGetLoadBalancersV2(t *testing.T) {
 	tests := []struct {
 		name          string
 		mocked        []*serviceConnector
-		expectedELBs  []*elbv2.DescribeLoadBalancersOutput
+		expectedELBs  map[string]elbv2.DescribeLoadBalancersOutput
 		expectedError error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -58,7 +58,7 @@ func TestGetLoadBalancersV2(t *testing.T) {
 			region:  "test",
 			service: elbv2.ServiceName,
 		}},
-		expectedELBs: nil,
+		expectedELBs: map[string]elbv2.DescribeLoadBalancersOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -77,8 +77,8 @@ func TestGetLoadBalancersV2(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedELBs: []*elbv2.DescribeLoadBalancersOutput{
-				{
+			expectedELBs: map[string]elbv2.DescribeLoadBalancersOutput{
+				"test": {
 					LoadBalancers: []*elbv2.LoadBalancer{
 						{
 							LoadBalancerName: aws.String("1"),
@@ -117,15 +117,15 @@ func TestGetLoadBalancersV2(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedELBs: []*elbv2.DescribeLoadBalancersOutput{
-				{
+			expectedELBs: map[string]elbv2.DescribeLoadBalancersOutput{
+				"test-1": {
 					LoadBalancers: []*elbv2.LoadBalancer{
 						{
 							LoadBalancerName: aws.String("1"),
 						},
 					},
 				},
-				{
+				"test-2": {
 					LoadBalancers: []*elbv2.LoadBalancer{
 						{
 							LoadBalancerName: aws.String("2"),
@@ -164,8 +164,8 @@ func TestGetLoadBalancersV2(t *testing.T) {
 					service: elbv2.ServiceName,
 				},
 			},
-			expectedELBs: []*elbv2.DescribeLoadBalancersOutput{
-				{
+			expectedELBs: map[string]elbv2.DescribeLoadBalancersOutput{
+				"test-2": {
 					LoadBalancers: []*elbv2.LoadBalancer{
 						{
 							LoadBalancerName: aws.String("2"),

--- a/elbv2_test.go
+++ b/elbv2_test.go
@@ -193,7 +193,7 @@ func TestGetLoadBalancersV2Tags(t *testing.T) {
 	tests := []struct {
 		name          string
 		mocked        []*serviceConnector
-		expectedTags  []*elbv2.DescribeTagsOutput
+		expectedTags  map[string]elbv2.DescribeTagsOutput
 		expectedError error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -210,7 +210,7 @@ func TestGetLoadBalancersV2Tags(t *testing.T) {
 			region:  "test",
 			service: elbv2.ServiceName,
 		}},
-		expectedTags: nil,
+		expectedTags: map[string]elbv2.DescribeTagsOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -229,8 +229,8 @@ func TestGetLoadBalancersV2Tags(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedTags: []*elbv2.DescribeTagsOutput{
-				{
+			expectedTags: map[string]elbv2.DescribeTagsOutput{
+				"test": {
 					TagDescriptions: []*elbv2.TagDescription{
 						{
 							ResourceArn: aws.String("1"),
@@ -269,15 +269,15 @@ func TestGetLoadBalancersV2Tags(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedTags: []*elbv2.DescribeTagsOutput{
-				{
+			expectedTags: map[string]elbv2.DescribeTagsOutput{
+				"test-1": {
 					TagDescriptions: []*elbv2.TagDescription{
 						{
 							ResourceArn: aws.String("1"),
 						},
 					},
 				},
-				{
+				"test-2": {
 					TagDescriptions: []*elbv2.TagDescription{
 						{
 							ResourceArn: aws.String("2"),
@@ -316,8 +316,8 @@ func TestGetLoadBalancersV2Tags(t *testing.T) {
 					service: elbv2.ServiceName,
 				},
 			},
-			expectedTags: []*elbv2.DescribeTagsOutput{
-				{
+			expectedTags: map[string]elbv2.DescribeTagsOutput{
+				"test-2": {
 					TagDescriptions: []*elbv2.TagDescription{
 						{
 							ResourceArn: aws.String("2"),

--- a/rds.go
+++ b/rds.go
@@ -8,9 +8,9 @@ import (
 
 func (c *connector) GetDBInstances(
 	ctx context.Context, input *rds.DescribeDBInstancesInput,
-) ([]*rds.DescribeDBInstancesOutput, error) {
+) (map[string]rds.DescribeDBInstancesOutput, error) {
 	var errs Errors
-	var instances []*rds.DescribeDBInstancesOutput
+	var instances = map[string]rds.DescribeDBInstancesOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.rds == nil {
@@ -20,7 +20,7 @@ func (c *connector) GetDBInstances(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, rds.ServiceName, err))
 		} else {
-			instances = append(instances, instance)
+			instances[svc.region] = *instance
 		}
 	}
 

--- a/rds.go
+++ b/rds.go
@@ -33,9 +33,9 @@ func (c *connector) GetDBInstances(
 
 func (c *connector) GetDBInstancesTags(
 	ctx context.Context, input *rds.ListTagsForResourceInput,
-) ([]*rds.ListTagsForResourceOutput, error) {
+) (map[string]rds.ListTagsForResourceOutput, error) {
 	var errs Errors
-	var rdsTags []*rds.ListTagsForResourceOutput
+	var rdsTags = map[string]rds.ListTagsForResourceOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.rds == nil {
@@ -45,7 +45,7 @@ func (c *connector) GetDBInstancesTags(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, rds.ServiceName, err))
 		} else {
-			rdsTags = append(rdsTags, rdsTag)
+			rdsTags[svc.region] = *rdsTag
 		}
 	}
 

--- a/rds_test.go
+++ b/rds_test.go
@@ -194,7 +194,7 @@ func TestGetDBInstancesTags(t *testing.T) {
 	tests := []struct {
 		name          string
 		mocked        []*serviceConnector
-		expectedTags  []*rds.ListTagsForResourceOutput
+		expectedTags  map[string]rds.ListTagsForResourceOutput
 		expectedError error
 	}{
 		{name: "one region no error",
@@ -215,8 +215,8 @@ func TestGetDBInstancesTags(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedTags: []*rds.ListTagsForResourceOutput{
-				{
+			expectedTags: map[string]rds.ListTagsForResourceOutput{
+				"test": {
 					TagList: []*rds.Tag{
 						{
 							Key:   aws.String("test"),
@@ -243,7 +243,7 @@ func TestGetDBInstancesTags(t *testing.T) {
 					service: rds.ServiceName,
 				},
 			},
-			expectedTags: nil,
+			expectedTags: map[string]rds.ListTagsForResourceOutput{},
 		},
 		{name: "multiple region no error",
 			mocked: []*serviceConnector{
@@ -277,8 +277,8 @@ func TestGetDBInstancesTags(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedTags: []*rds.ListTagsForResourceOutput{
-				{
+			expectedTags: map[string]rds.ListTagsForResourceOutput{
+				"test-1": {
 					TagList: []*rds.Tag{
 						{
 							Key:   aws.String("test"),
@@ -286,7 +286,7 @@ func TestGetDBInstancesTags(t *testing.T) {
 						},
 					},
 				},
-				{
+				"test-2": {
 					TagList: []*rds.Tag{
 						{
 							Key:   aws.String("test"),
@@ -327,8 +327,8 @@ func TestGetDBInstancesTags(t *testing.T) {
 					service: rds.ServiceName,
 				},
 			},
-			expectedTags: []*rds.ListTagsForResourceOutput{
-				{
+			expectedTags: map[string]rds.ListTagsForResourceOutput{
+				"test-2": {
 					TagList: []*rds.Tag{
 						{
 							Key:   aws.String("test"),

--- a/rds_test.go
+++ b/rds_test.go
@@ -40,7 +40,7 @@ func TestGetDBInstances(t *testing.T) {
 	tests := []struct {
 		name              string
 		mocked            []*serviceConnector
-		expectedInstances []*rds.DescribeDBInstancesOutput
+		expectedInstances map[string]rds.DescribeDBInstancesOutput
 		expectedError     error
 	}{{
 		name: "one region no error",
@@ -60,8 +60,8 @@ func TestGetDBInstances(t *testing.T) {
 			},
 		},
 		expectedError: nil,
-		expectedInstances: []*rds.DescribeDBInstancesOutput{
-			{
+		expectedInstances: map[string]rds.DescribeDBInstancesOutput{
+			"test": {
 				DBInstances: []*rds.DBInstance{
 					{
 						DbiResourceId: aws.String("1"),
@@ -87,7 +87,7 @@ func TestGetDBInstances(t *testing.T) {
 					service: rds.ServiceName,
 				},
 			},
-			expectedInstances: nil,
+			expectedInstances: map[string]rds.DescribeDBInstancesOutput{},
 		},
 		{name: "multiple region with error",
 			mocked: []*serviceConnector{
@@ -119,8 +119,8 @@ func TestGetDBInstances(t *testing.T) {
 					service: rds.ServiceName,
 				},
 			},
-			expectedInstances: []*rds.DescribeDBInstancesOutput{
-				{
+			expectedInstances: map[string]rds.DescribeDBInstancesOutput{
+				"test-2": {
 					DBInstances: []*rds.DBInstance{
 						{
 							DbiResourceId: aws.String("2"),
@@ -159,15 +159,15 @@ func TestGetDBInstances(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedInstances: []*rds.DescribeDBInstancesOutput{
-				{
+			expectedInstances: map[string]rds.DescribeDBInstancesOutput{
+				"test-1": {
 					DBInstances: []*rds.DBInstance{
 						{
 							DbiResourceId: aws.String("1"),
 						},
 					},
 				},
-				{
+				"test-2": {
 					DBInstances: []*rds.DBInstance{
 						{
 							DbiResourceId: aws.String("2"),

--- a/s3.go
+++ b/s3.go
@@ -61,9 +61,9 @@ func (c *connector) GetBucketTags(
 
 func (c *connector) ListObjects(
 	ctx context.Context, input *s3.ListObjectsInput,
-) ([]*s3.ListObjectsOutput, error) {
+) (map[string]s3.ListObjectsOutput, error) {
 	var errs Errors
-	var objectsList []*s3.ListObjectsOutput
+	var objectsList = map[string]s3.ListObjectsOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.s3 == nil {
@@ -73,7 +73,7 @@ func (c *connector) ListObjects(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, s3.ServiceName, err))
 		} else {
-			objectsList = append(objectsList, buckets)
+			objectsList[svc.region] = *buckets
 		}
 	}
 

--- a/s3.go
+++ b/s3.go
@@ -107,9 +107,9 @@ func (c *connector) DownloadObject(
 
 func (c *connector) GetObjectsTags(
 	ctx context.Context, input *s3.GetObjectTaggingInput,
-) ([]*s3.GetObjectTaggingOutput, error) {
+) (map[string]s3.GetObjectTaggingOutput, error) {
 	var errs Errors
-	var objectsTagsList []*s3.GetObjectTaggingOutput
+	var objectsTagsList = map[string]s3.GetObjectTaggingOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.s3 == nil {
@@ -119,7 +119,7 @@ func (c *connector) GetObjectsTags(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, s3.ServiceName, err))
 		} else {
-			objectsTagsList = append(objectsTagsList, buckets)
+			objectsTagsList[svc.region] = *buckets
 		}
 	}
 

--- a/s3.go
+++ b/s3.go
@@ -11,9 +11,9 @@ import (
 
 func (c *connector) ListBuckets(
 	ctx context.Context, input *s3.ListBucketsInput,
-) ([]*s3.ListBucketsOutput, error) {
+) (map[string]s3.ListBucketsOutput, error) {
 	var errs Errors
-	var bucketsList []*s3.ListBucketsOutput
+	var bucketsList = map[string]s3.ListBucketsOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.s3 == nil {
@@ -23,7 +23,7 @@ func (c *connector) ListBuckets(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, s3.ServiceName, err))
 		} else {
-			bucketsList = append(bucketsList, buckets)
+			bucketsList[svc.region] = *buckets
 		}
 	}
 

--- a/s3.go
+++ b/s3.go
@@ -36,9 +36,9 @@ func (c *connector) ListBuckets(
 
 func (c *connector) GetBucketTags(
 	ctx context.Context, input *s3.GetBucketTaggingInput,
-) ([]*s3.GetBucketTaggingOutput, error) {
+) (map[string]s3.GetBucketTaggingOutput, error) {
 	var errs Errors
-	var bucketsTagList []*s3.GetBucketTaggingOutput
+	var bucketsTagList = map[string]s3.GetBucketTaggingOutput{}
 
 	for _, svc := range c.svcs {
 		if svc.s3 == nil {
@@ -48,7 +48,7 @@ func (c *connector) GetBucketTags(
 		if err != nil {
 			errs = append(errs, NewError(svc.region, s3.ServiceName, err))
 		} else {
-			bucketsTagList = append(bucketsTagList, bucketsTags)
+			bucketsTagList[svc.region] = *bucketsTags
 		}
 	}
 

--- a/s3_test.go
+++ b/s3_test.go
@@ -548,7 +548,7 @@ func TestGetObjectsTags(t *testing.T) {
 	tests := []struct {
 		name          string
 		mocked        []*serviceConnector
-		expectedTags  []*s3.GetObjectTaggingOutput
+		expectedTags  map[string]s3.GetObjectTaggingOutput
 		expectedError error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -565,7 +565,7 @@ func TestGetObjectsTags(t *testing.T) {
 			region:  "test",
 			service: s3.ServiceName,
 		}},
-		expectedTags: nil,
+		expectedTags: map[string]s3.GetObjectTaggingOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -580,8 +580,8 @@ func TestGetObjectsTags(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedTags: []*s3.GetObjectTaggingOutput{
-				{
+			expectedTags: map[string]s3.GetObjectTaggingOutput{
+				"test": {
 					VersionId: aws.String("test"),
 				},
 			},
@@ -608,11 +608,11 @@ func TestGetObjectsTags(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedTags: []*s3.GetObjectTaggingOutput{
-				{
+			expectedTags: map[string]s3.GetObjectTaggingOutput{
+				"test-1": {
 					VersionId: aws.String("test-1"),
 				},
-				{
+				"test-2": {
 					VersionId: aws.String("test-2"),
 				},
 			},
@@ -641,8 +641,8 @@ func TestGetObjectsTags(t *testing.T) {
 				region:  "test-1",
 				service: s3.ServiceName,
 			}},
-			expectedTags: []*s3.GetObjectTaggingOutput{
-				{
+			expectedTags: map[string]s3.GetObjectTaggingOutput{
+				"test-2": {
 					VersionId: aws.String("test-2"),
 				},
 			},

--- a/s3_test.go
+++ b/s3_test.go
@@ -357,7 +357,7 @@ func TestListObjects(t *testing.T) {
 	tests := []struct {
 		name            string
 		mocked          []*serviceConnector
-		expectedObjects []*s3.ListObjectsOutput
+		expectedObjects map[string]s3.ListObjectsOutput
 		expectedError   error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -374,7 +374,7 @@ func TestListObjects(t *testing.T) {
 			region:  "test",
 			service: s3.ServiceName,
 		}},
-		expectedObjects: nil,
+		expectedObjects: map[string]s3.ListObjectsOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -389,8 +389,8 @@ func TestListObjects(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedObjects: []*s3.ListObjectsOutput{
-				{
+			expectedObjects: map[string]s3.ListObjectsOutput{
+				"test": {
 					Name: aws.String("test"),
 				},
 			},
@@ -417,11 +417,11 @@ func TestListObjects(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedObjects: []*s3.ListObjectsOutput{
-				{
+			expectedObjects: map[string]s3.ListObjectsOutput{
+				"test-1": {
 					Name: aws.String("test-1"),
 				},
-				{
+				"test-2": {
 					Name: aws.String("test-2"),
 				},
 			},
@@ -449,8 +449,8 @@ func TestListObjects(t *testing.T) {
 				region:  "test-1",
 				service: s3.ServiceName,
 			}},
-			expectedObjects: []*s3.ListObjectsOutput{
-				{
+			expectedObjects: map[string]s3.ListObjectsOutput{
+				"test-2": {
 					Name: aws.String("test-2"),
 				},
 			},

--- a/s3_test.go
+++ b/s3_test.go
@@ -216,7 +216,7 @@ func TestGetBucketTags(t *testing.T) {
 	tests := []struct {
 		name          string
 		mocked        []*serviceConnector
-		expectedTags  []*s3.GetBucketTaggingOutput
+		expectedTags  map[string]s3.GetBucketTaggingOutput
 		expectedError error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -233,7 +233,7 @@ func TestGetBucketTags(t *testing.T) {
 			region:  "test",
 			service: s3.ServiceName,
 		}},
-		expectedTags: nil,
+		expectedTags: map[string]s3.GetBucketTaggingOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -251,8 +251,8 @@ func TestGetBucketTags(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedTags: []*s3.GetBucketTaggingOutput{
-				{
+			expectedTags: map[string]s3.GetBucketTaggingOutput{
+				"test": {
 					TagSet: []*s3.Tag{{
 						Key:   aws.String("test"),
 						Value: aws.String("1"),
@@ -288,14 +288,14 @@ func TestGetBucketTags(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedTags: []*s3.GetBucketTaggingOutput{
-				{
+			expectedTags: map[string]s3.GetBucketTaggingOutput{
+				"test-1": {
 					TagSet: []*s3.Tag{{
 						Key:   aws.String("test"),
 						Value: aws.String("1"),
 					}},
 				},
-				{
+				"test-2": {
 					TagSet: []*s3.Tag{{
 						Key:   aws.String("test"),
 						Value: aws.String("2"),
@@ -330,8 +330,8 @@ func TestGetBucketTags(t *testing.T) {
 				region:  "test-1",
 				service: s3.ServiceName,
 			}},
-			expectedTags: []*s3.GetBucketTaggingOutput{
-				{
+			expectedTags: map[string]s3.GetBucketTaggingOutput{
+				"test-2": {
 					TagSet: []*s3.Tag{{
 						Key:   aws.String("test"),
 						Value: aws.String("2"),

--- a/s3_test.go
+++ b/s3_test.go
@@ -83,7 +83,7 @@ func TestListBuckets(t *testing.T) {
 	tests := []struct {
 		name            string
 		mocked          []*serviceConnector
-		expectedBuckets []*s3.ListBucketsOutput
+		expectedBuckets map[string]s3.ListBucketsOutput
 		expectedError   error
 	}{{name: "one region with error",
 		mocked: []*serviceConnector{
@@ -100,7 +100,7 @@ func TestListBuckets(t *testing.T) {
 			region:  "test",
 			service: s3.ServiceName,
 		}},
-		expectedBuckets: nil,
+		expectedBuckets: map[string]s3.ListBucketsOutput{},
 	},
 		{name: "one region no error",
 			mocked: []*serviceConnector{
@@ -117,8 +117,8 @@ func TestListBuckets(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedBuckets: []*s3.ListBucketsOutput{
-				{
+			expectedBuckets: map[string]s3.ListBucketsOutput{
+				"test": {
 					Buckets: []*s3.Bucket{{
 						Name: aws.String("test"),
 					}},
@@ -151,13 +151,13 @@ func TestListBuckets(t *testing.T) {
 				},
 			},
 			expectedError: nil,
-			expectedBuckets: []*s3.ListBucketsOutput{
-				{
+			expectedBuckets: map[string]s3.ListBucketsOutput{
+				"test-1": {
 					Buckets: []*s3.Bucket{{
 						Name: aws.String("test-1"),
 					}},
 				},
-				{
+				"test-2": {
 					Buckets: []*s3.Bucket{{
 						Name: aws.String("test-2"),
 					}},
@@ -190,8 +190,8 @@ func TestListBuckets(t *testing.T) {
 				region:  "test-1",
 				service: s3.ServiceName,
 			}},
-			expectedBuckets: []*s3.ListBucketsOutput{
-				{
+			expectedBuckets: map[string]s3.ListBucketsOutput{
+				"test-2": {
 					Buckets: []*s3.Bucket{{
 						Name: aws.String("test-2"),
 					}},


### PR DESCRIPTION
For convenience of not having conflicts with so close open PRs, this branch is on top of the change of #25 

All the context of this PR is in #16 and the commit messages should contain enough information of the changes applied.

It's worth to mention that I haven't changed the returned types by the AWS as I mentioned #16 as a further improvement, mostly because some of them [could not be changed because they contain more than one field](https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeInstancesOutput) and others [only one field](https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#DescribeImagesOutput) (which could be changed), hence for homogeneity I decided not to change only the ones that we could.




closes #16 