### PR TITLE
Upgrade Go to 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
- - 1.9.3
+ - "1.10"
 
 before_install:
  - go get -v github.com/mattn/goveralls


### PR DESCRIPTION
Upgrade the Go version to use the last stable release, the 1.10.

https://blog.golang.org/go1.10