### PR TITLE
Define and implement GetRecordedResourcesCounts

### DIFF
--- a/configservice.go
+++ b/configservice.go
@@ -1,0 +1,32 @@
+package raws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/configservice"
+)
+
+func (c *connector) GetRecordedResourceCounts(
+	ctx context.Context, input *configservice.GetDiscoveredResourceCountsInput,
+) (map[string]configservice.GetDiscoveredResourceCountsOutput, error) {
+	var errs Errors
+	var resCounts = map[string]configservice.GetDiscoveredResourceCountsOutput{}
+
+	for _, svc := range c.svcs {
+		if svc.configservice == nil {
+			svc.configservice = configservice.New(svc.session)
+		}
+		counts, err := svc.configservice.GetDiscoveredResourceCountsWithContext(ctx, input)
+		if err != nil {
+			errs = append(errs, NewError(svc.region, configservice.ServiceName, err))
+		} else {
+			resCounts[svc.region] = *counts
+		}
+	}
+
+	if errs != nil {
+		return resCounts, errs
+	}
+
+	return resCounts, nil
+}

--- a/configservice_test.go
+++ b/configservice_test.go
@@ -1,0 +1,267 @@
+package raws
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/configservice"
+	"github.com/aws/aws-sdk-go/service/configservice/configserviceiface"
+)
+
+type mockServiceConfig struct {
+	configserviceiface.ConfigServiceAPI
+
+	gdrcctx    context.Context
+	gdrcinput  *configservice.GetDiscoveredResourceCountsInput
+	gdrcoutput *configservice.GetDiscoveredResourceCountsOutput
+	gdrcerr    error
+}
+
+func (m *mockServiceConfig) GetDiscoveredResourceCountsWithContext(
+	ctx aws.Context, input *configservice.GetDiscoveredResourceCountsInput, _ ...request.Option,
+) (*configservice.GetDiscoveredResourceCountsOutput, error) {
+	m.gdrcctx = ctx
+	m.gdrcinput = input
+	return m.gdrcoutput, m.gdrcerr
+}
+
+func TestGetRecordedResourceCounts(t *testing.T) {
+	t.Run("input parameter is nil", testGetRecordedResourceCountsInputParameterNil)
+	t.Run("input parameter isn't nil", testGetRecordedResourceCountsInputParameterNotNil)
+	t.Run("one region with error", testGetRecordedResourceCountsOneRegionError)
+	t.Run("one region no error", testGetRecordedResourceCountsOneRegionNoError)
+	t.Run("multiple region no error", testGetRecordedResourceCountsMultipleRegionsNoError)
+	t.Run("multiple region with error", testGetRecordedResourceCountsMultipleRegionsOneError)
+}
+
+// testGetRecordedResourceCountsInputParemeterNil checks that when the input
+// parameters passed to the AWSReader instance GetRecordedResourceCounts method
+// is nil, nil is passed down to the AWS SDK GetDiscoveredResourceCounts
+func testGetRecordedResourceCountsInputParameterNil(t *testing.T) {
+	var (
+		ctx  = context.Background()
+		mock = &mockServiceConfig{
+			gdrcoutput: &configservice.GetDiscoveredResourceCountsOutput{},
+			gdrcerr:    nil,
+		}
+
+		awsReader = &connector{
+			svcs: []*serviceConnector{{region: "test", configservice: mock}},
+		}
+	)
+
+	_, _ = awsReader.GetRecordedResourceCounts(ctx, nil)
+	if !reflect.DeepEqual(mock.gdrcctx, ctx) {
+		t.Errorf(
+			"Passed context to AWS SDK isn't the one passed to the AWSReader method. received=%+v | expected=%+v",
+			mock.gdrcctx,
+			ctx,
+		)
+	}
+
+	if mock.gdrcinput != nil {
+		t.Errorf(
+			"Passed input to AWS SDK isn't nil. received=%+v | expected=nil",
+			mock.gdrcinput,
+		)
+	}
+}
+
+// testGetRecordedResourceCountsInputParemeterNotNil checks that when the input
+// parameters passed to the AWSReader instance GetRecordedResourceCounts method
+// is passed down to the AWS SDK GetDiscoveredResourceCounts
+func testGetRecordedResourceCountsInputParameterNotNil(t *testing.T) {
+	var (
+		ctx   = context.Background()
+		input = &configservice.GetDiscoveredResourceCountsInput{
+			NextToken: aws.String("some-test-token"),
+		}
+		mock = &mockServiceConfig{
+			gdrcoutput: &configservice.GetDiscoveredResourceCountsOutput{},
+			gdrcerr:    nil,
+		}
+
+		awsReader = &connector{
+			svcs: []*serviceConnector{{region: "test", configservice: mock}},
+		}
+	)
+
+	_, _ = awsReader.GetRecordedResourceCounts(ctx, input)
+	if !reflect.DeepEqual(mock.gdrcctx, ctx) {
+		t.Errorf(
+			"Passed context to AWS SDK isn't the one passed to the AWSReader method. received=%+v | expected=%+v",
+			mock.gdrcctx,
+			ctx,
+		)
+	}
+
+	if !reflect.DeepEqual(mock.gdrcinput, input) {
+		t.Errorf(
+			"Passed input to AWS SDK isn't the one passed to the AWSReader method. received=%+v | expected=%+v",
+			mock.gdrcinput,
+			input,
+		)
+	}
+}
+
+// testGetRecordedResourceCountsOneRegionError checks that when the AWS SDK
+// GetDiscoveredResourceCounts return an error in the only one region, it's
+// returned.
+func testGetRecordedResourceCountsOneRegionError(t *testing.T) {
+	var (
+		ctx  = context.Background()
+		mock = &mockServiceConfig{
+			gdrcoutput: nil,
+			gdrcerr: Errors{Error{
+				err:     errors.New("error with test"),
+				region:  "test",
+				service: configservice.ServiceName,
+			}},
+		}
+
+		awsReader = &connector{
+			svcs: []*serviceConnector{{region: "test", configservice: mock}},
+		}
+	)
+
+	var _, err = awsReader.GetRecordedResourceCounts(ctx, nil)
+
+	var expectedErrors = Errors{
+		Error{
+			err:     mock.gdrcerr,
+			region:  "test",
+			service: configservice.ServiceName,
+		},
+	}
+	checkError(t, err, expectedErrors)
+}
+
+// testGetRecordedResourceCountsOneRegionNoError checks that when the AWS SDK
+// GetDiscoveredResourceCounts return a no error result in the only one region,
+// the result is returned associated to the region.
+func testGetRecordedResourceCountsOneRegionNoError(t *testing.T) {
+	var (
+		ctx  = context.Background()
+		mock = &mockServiceConfig{
+			gdrcoutput: &configservice.GetDiscoveredResourceCountsOutput{
+				ResourceCounts: []*configservice.ResourceCount{
+					{ResourceType: aws.String("some-resource-1")},
+					{ResourceType: aws.String("some-resource-2")},
+				},
+			},
+			gdrcerr: nil,
+		}
+		awsReader = &connector{
+			svcs: []*serviceConnector{{region: "test", configservice: mock}},
+		}
+	)
+
+	var counts, err = awsReader.GetRecordedResourceCounts(ctx, nil)
+	if err != nil {
+		t.Errorf("Unexpected returned error. received= %+v | expected=nil", err)
+	}
+
+	var expectedCounts = map[string]configservice.GetDiscoveredResourceCountsOutput{
+		"test": *mock.gdrcoutput,
+	}
+	if !reflect.DeepEqual(counts, expectedCounts) {
+		t.Errorf("resource counts: received=%+v | expected=%+v", counts, expectedCounts)
+	}
+}
+
+// testGetRecordedResourceCountsMultipleRegionsNoError checks that when the AWS
+// SDK GetDiscoveredResourceCounts return a no error result in all the regions,
+// and the results are associated to the corresponding regions.
+func testGetRecordedResourceCountsMultipleRegionsNoError(t *testing.T) {
+	var (
+		ctx      = context.Background()
+		mockReg1 = &mockServiceConfig{
+			gdrcoutput: &configservice.GetDiscoveredResourceCountsOutput{
+				ResourceCounts: []*configservice.ResourceCount{
+					{ResourceType: aws.String("some-resource-reg1-1")},
+					{ResourceType: aws.String("some-resource-reg2-2")},
+				},
+			},
+			gdrcerr: nil,
+		}
+		mockReg2 = &mockServiceConfig{
+			gdrcoutput: &configservice.GetDiscoveredResourceCountsOutput{
+				ResourceCounts: []*configservice.ResourceCount{
+					{ResourceType: aws.String("some-resource-reg2-1")},
+					{ResourceType: aws.String("some-resource-reg2-2")},
+				},
+			},
+			gdrcerr: nil,
+		}
+		awsReader = &connector{
+			svcs: []*serviceConnector{
+				{region: "region-1", configservice: mockReg1},
+				{region: "region-2", configservice: mockReg2},
+			},
+		}
+	)
+
+	var counts, err = awsReader.GetRecordedResourceCounts(ctx, nil)
+	if err != nil {
+		t.Errorf("Unexpected returned error. received= %+v | expected=nil", err)
+	}
+
+	var expectedCounts = map[string]configservice.GetDiscoveredResourceCountsOutput{
+		"region-1": *mockReg1.gdrcoutput,
+		"region-2": *mockReg2.gdrcoutput,
+	}
+	if !reflect.DeepEqual(counts, expectedCounts) {
+		t.Errorf("resource counts: received=%+v | expected=%+v", counts, expectedCounts)
+	}
+}
+
+// testGetRecordedResourceCountsMultipleRegionsOneError checks that when the AWS
+// SDK GetDiscoveredResourceCounts return the error result in the correct region,
+// and it returns the results (partial) to the regions which didn't respond with
+// an error
+func testGetRecordedResourceCountsMultipleRegionsOneError(t *testing.T) {
+	var (
+		ctx      = context.Background()
+		mockReg1 = &mockServiceConfig{
+			gdrcoutput: nil,
+			gdrcerr:    errors.New("error with region-1"),
+		}
+		mockReg2 = &mockServiceConfig{
+			gdrcoutput: &configservice.GetDiscoveredResourceCountsOutput{
+				ResourceCounts: []*configservice.ResourceCount{
+					{ResourceType: aws.String("some-resource-reg2-1")},
+					{ResourceType: aws.String("some-resource-reg2-2")},
+				},
+			},
+			gdrcerr: nil,
+		}
+		awsReader = &connector{
+			svcs: []*serviceConnector{
+				{region: "region-1", configservice: mockReg1},
+				{region: "region-2", configservice: mockReg2},
+			},
+		}
+	)
+
+	var counts, err = awsReader.GetRecordedResourceCounts(ctx, nil)
+
+	var expectedErrors = Errors{
+		Error{
+			err:     mockReg1.gdrcerr,
+			region:  "region-1",
+			service: configservice.ServiceName,
+		},
+	}
+	checkError(t, err, expectedErrors)
+
+	var expectedCounts = map[string]configservice.GetDiscoveredResourceCountsOutput{
+		"region-2": *mockReg2.gdrcoutput,
+	}
+	if !reflect.DeepEqual(counts, expectedCounts) {
+		t.Errorf("resource counts: received=%+v | expected=%+v", counts, expectedCounts)
+	}
+}

--- a/connector.go
+++ b/connector.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/configservice"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -148,6 +149,15 @@ type AWSReader interface {
 	// GetObjectsTags returns tags associated with S3 objects based on the input given.
 	// Returned values are commented in the interface doc comment block.
 	GetObjectsTags(ctx context.Context, input *s3.GetObjectTaggingInput) (map[string]s3.GetObjectTaggingOutput, error)
+
+	// GetRecordedResourceCounts returns counts of the AWS resources which have
+	// been recorded by AWS Config.
+	// See https://docs.aws.amazon.com/config/latest/APIReference/API_GetDiscoveredResourceCounts.html
+	// for more information about what to enable in your AWS account, the list of
+	// supported resources, etc.
+	GetRecordedResourceCounts(
+		ctx context.Context, input *configservice.GetDiscoveredResourceCountsInput,
+	) (map[string]configservice.GetDiscoveredResourceCountsOutput, error)
 }
 
 // NewAWSReader returns an object which also contains the accountID and extend the different regions to use.

--- a/connector.go
+++ b/connector.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/configservice"
+	"github.com/aws/aws-sdk-go/service/configservice/configserviceiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -214,15 +215,16 @@ func (c *connector) GetRegions() []string {
 }
 
 type serviceConnector struct {
-	region       string
-	session      *session.Session
-	ec2          ec2iface.EC2API
-	elb          elbiface.ELBAPI
-	elbv2        elbv2iface.ELBV2API
-	rds          rdsiface.RDSAPI
-	s3           s3iface.S3API
-	s3downloader s3manageriface.DownloaderAPI
-	elasticache  elasticacheiface.ElastiCacheAPI
+	region        string
+	session       *session.Session
+	ec2           ec2iface.EC2API
+	elb           elbiface.ELBAPI
+	elbv2         elbv2iface.ELBV2API
+	rds           rdsiface.RDSAPI
+	s3            s3iface.S3API
+	s3downloader  s3manageriface.DownloaderAPI
+	elasticache   elasticacheiface.ElastiCacheAPI
+	configservice configserviceiface.ConfigServiceAPI
 }
 
 func configureAWS(accessKey string, secretKey string) (*credentials.Credentials, ec2iface.EC2API, stsiface.STSAPI, error) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -9,11 +9,25 @@ func checkErrors(t *testing.T, name string, index int, err error, expected error
 	t.Helper()
 
 	if err == nil && expected != nil {
-		t.Errorf("%s [%d] - errors: received=nil | expected=%v", name, index, expected)
+		if index >= 0 {
+			t.Errorf("%s [%d] - errors: received=nil | expected=%v", name, index, expected)
+		} else {
+			t.Errorf("%s - errors: received=nil | expected=%v", name, expected)
+		}
+
 		return
 	}
 
 	if !reflect.DeepEqual(err, expected) {
-		t.Errorf("%s [%d] - errors: received=%+v | expected=%+v", name, index, err, expected)
+		if index >= 0 {
+			t.Errorf("%s [%d] - errors: received=%+v | expected=%+v", name, index, err, expected)
+		} else {
+			t.Errorf("%s - errors: received=%+v | expected=%+v", name, index, expected)
+		}
 	}
+}
+
+func checkError(t *testing.T, err error, expected error) {
+	t.Helper()
+	checkErrors(t, t.Name(), -1, err, expected)
 }


### PR DESCRIPTION
This is contains the definition and the implementation of the `GetRecordedResourcesCounts` `AWSReader` method in order to have a wrapper around the [`configservice.GetDiscoveredResourceCountsWithContext`](https://docs.aws.amazon.com/sdk-for-go/api/service/configservice/#ConfigService.GetDiscoveredResourceCountsWithContext)

closes #30 
