### PR TITLE
Update Go 1.10 to the patch version 1.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: false
 go:
- - "1.10"
+ - "1.10.1"
 
 before_install:
  - go get -v github.com/mattn/goveralls


### PR DESCRIPTION
Update Golang version to use in the CI for using the last and first
patch version of the minor version 1.10.