### PR TITLE
connector: Change the 'GetElastiCacheCluster' to 'GetElastiCacheClusters'

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -84,9 +84,9 @@ type AWSReader interface {
 	// Returned values are commented in the interface doc comment block.
 	GetSnapshots(ctx context.Context, input *ec2.DescribeSnapshotsInput) (map[string]ec2.DescribeSnapshotsOutput, error)
 
-	// GetElastiCacheCluster returns all Elasticache clusters based on the input given.
+	// GetElastiCacheClusters returns all Elasticache clusters based on the input given.
 	// Returned values are commented in the interface doc comment block.
-	GetElastiCacheCluster(
+	GetElastiCacheClusters(
 		ctx context.Context, input *elasticache.DescribeCacheClustersInput,
 	) (map[string]elasticache.DescribeCacheClustersOutput, error)
 

--- a/elasticache.go
+++ b/elasticache.go
@@ -6,7 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticache"
 )
 
-func (c *connector) GetElastiCacheCluster(
+func (c *connector) GetElastiCacheClusters(
 	ctx context.Context, input *elasticache.DescribeCacheClustersInput,
 ) (map[string]elasticache.DescribeCacheClustersOutput, error) {
 	var errs Errors

--- a/elasticache_test.go
+++ b/elasticache_test.go
@@ -179,7 +179,7 @@ func TestGetElastiCacheCluster(t *testing.T) {
 
 	for i, tt := range tests {
 		c := &connector{svcs: tt.mocked}
-		cluster, err := c.GetElastiCacheCluster(ctx, nil)
+		cluster, err := c.GetElastiCacheClusters(ctx, nil)
 		checkErrors(t, tt.name, i, err, tt.expectedError)
 		if !reflect.DeepEqual(cluster, tt.expectedClusters) {
 			t.Errorf("%s [%d] - clusters: received=%+v | expected=%+v",

--- a/example_elasticache_test.go
+++ b/example_elasticache_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cycloidio/raws"
 )
 
-func ExampleAWSReader_GetElastiCacheCluster() {
+func ExampleAWSReader_GetElastiCacheClusters() {
 	var accessKey, secretKey, err = getAWSKeys()
 	if err != nil {
 		// When no keys the example doesn't run, but if the env vars are set
@@ -25,7 +25,7 @@ func ExampleAWSReader_GetElastiCacheCluster() {
 	}
 
 	var deci = &elasticache.DescribeCacheClustersInput{}
-	var _, awsErrs = awsr.GetElastiCacheCluster(ctx, deci)
+	var _, awsErrs = awsr.GetElastiCacheClusters(ctx, deci)
 	if awsErrs != nil {
 		fmt.Printf("Error: %+v\n", awsErrs)
 		return

--- a/example_test.go
+++ b/example_test.go
@@ -72,7 +72,7 @@ func callRDS(c raws.AWSReader) {
 func callElastiCache(c raws.AWSReader) {
 	var ctx = context.Background()
 
-	clusters, _ := c.GetElastiCacheCluster(ctx, nil)
+	clusters, _ := c.GetElastiCacheClusters(ctx, nil)
 	fmt.Println(clusters)
 
 	i := &elasticache.ListTagsForResourceInput{


### PR DESCRIPTION
To keep the right consistency on the naming

Closes #22 