### PR TITLE
Added: Cloudfront to the lists

### DIFF
--- a/cloudfront.go
+++ b/cloudfront.go
@@ -55,3 +55,28 @@ func (c *connector) GetCloudFrontPublicKeys(
 
 	return regionPublicKeys, nil
 }
+
+func (c *connector) GetCloudFrontOriginAccessIdentities(
+	ctx context.Context, input *cloudfront.ListCloudFrontOriginAccessIdentitiesInput,
+) (map[string]cloudfront.ListCloudFrontOriginAccessIdentitiesOutput, error) {
+	var errs Errors
+	var regionOriginAccessIdentities = map[string]cloudfront.ListCloudFrontOriginAccessIdentitiesOutput{}
+
+	for _, svc := range c.svcs {
+		if svc.cloudfront == nil {
+			svc.cloudfront = cloudfront.New(svc.session)
+		}
+		originAccessIdentities, err := svc.cloudfront.ListCloudFrontOriginAccessIdentitiesWithContext(ctx, input)
+		if err != nil {
+			errs = append(errs, NewError(svc.region, cloudfront.ServiceName, err))
+		} else {
+			regionOriginAccessIdentities[svc.region] = *originAccessIdentities
+		}
+	}
+
+	if errs != nil {
+		return regionOriginAccessIdentities, errs
+	}
+
+	return regionOriginAccessIdentities, nil
+}

--- a/cloudfront_test.go
+++ b/cloudfront_test.go
@@ -15,15 +15,25 @@ import (
 type mockCloudFront struct {
 	cloudfrontiface.CloudFrontAPI
 
-	// Mock of DescribeInstances
-	ldo    *cloudfront.ListDistributionsOutput
-	ldoerr error
+	// Mock of ListDistributionsOutput
+	ldo   *cloudfront.ListDistributionsOutput
+	lderr error
+
+	// Mock of  ListPublicKeysOutput
+	lpko   *cloudfront.ListPublicKeysOutput
+	lpkerr error
 }
 
 func (m mockCloudFront) ListDistributionsWithContext(
 	_ aws.Context, _ *cloudfront.ListDistributionsInput, _ ...request.Option,
 ) (*cloudfront.ListDistributionsOutput, error) {
-	return m.ldo, m.ldoerr
+	return m.ldo, m.lderr
+}
+
+func (m mockCloudFront) ListPublicKeysWithContext(
+	_ aws.Context, _ *cloudfront.ListPublicKeysInput, _ ...request.Option,
+) (*cloudfront.ListPublicKeysOutput, error) {
+	return m.lpko, m.lpkerr
 }
 
 func TestGetCloudFrontDistributions(t *testing.T) {
@@ -39,8 +49,8 @@ func TestGetCloudFrontDistributions(t *testing.T) {
 				{
 					region: "test",
 					cloudfront: mockCloudFront{
-						ldo:    &cloudfront.ListDistributionsOutput{},
-						ldoerr: errors.New("error with test"),
+						ldo:   &cloudfront.ListDistributionsOutput{},
+						lderr: errors.New("error with test"),
 					},
 				},
 			},
@@ -66,7 +76,7 @@ func TestGetCloudFrontDistributions(t *testing.T) {
 								},
 							},
 						},
-						ldoerr: nil,
+						lderr: nil,
 					},
 				},
 			},
@@ -98,7 +108,7 @@ func TestGetCloudFrontDistributions(t *testing.T) {
 								},
 							},
 						},
-						ldoerr: nil,
+						lderr: nil,
 					},
 				},
 				{
@@ -113,7 +123,7 @@ func TestGetCloudFrontDistributions(t *testing.T) {
 								},
 							},
 						},
-						ldoerr: nil,
+						lderr: nil,
 					},
 				},
 			},
@@ -145,8 +155,8 @@ func TestGetCloudFrontDistributions(t *testing.T) {
 				{
 					region: "test-1",
 					cloudfront: mockCloudFront{
-						ldo:    &cloudfront.ListDistributionsOutput{},
-						ldoerr: errors.New("error with test-1"),
+						ldo:   &cloudfront.ListDistributionsOutput{},
+						lderr: errors.New("error with test-1"),
 					},
 				},
 				{
@@ -161,7 +171,7 @@ func TestGetCloudFrontDistributions(t *testing.T) {
 								},
 							},
 						},
-						ldoerr: nil,
+						lderr: nil,
 					},
 				},
 			},
@@ -189,6 +199,177 @@ func TestGetCloudFrontDistributions(t *testing.T) {
 	for i, tt := range tests {
 		c := &connector{svcs: tt.mocked}
 		opt, err := c.GetCloudFrontDistributions(ctx, nil)
+		checkErrors(t, tt.name, i, err, tt.expectedErr)
+		if !reflect.DeepEqual(opt, tt.expectedOpt) {
+			t.Errorf("%s [%d] - EC2 instances: received=%+v | expected=%+v",
+				tt.name, i, opt, tt.expectedOpt)
+		}
+	}
+}
+
+func TestGetCloudFrontPublicKeys(t *testing.T) {
+	tests := []struct {
+		name        string
+		mocked      []*serviceConnector
+		expectedOpt map[string]cloudfront.ListPublicKeysOutput
+		expectedErr error
+	}{
+		{
+			name: "one region with error",
+			mocked: []*serviceConnector{
+				{
+					region: "test",
+					cloudfront: mockCloudFront{
+						lpko:   &cloudfront.ListPublicKeysOutput{},
+						lpkerr: errors.New("error with test"),
+					},
+				},
+			},
+			expectedErr: Errors{Error{
+				err:     errors.New("error with test"),
+				region:  "test",
+				service: cloudfront.ServiceName,
+			}},
+			expectedOpt: map[string]cloudfront.ListPublicKeysOutput{},
+		},
+		{
+			name: "one region no error",
+			mocked: []*serviceConnector{
+				{
+					region: "test",
+					cloudfront: mockCloudFront{
+						lpko: &cloudfront.ListPublicKeysOutput{
+							PublicKeyList: &cloudfront.PublicKeyList{
+								Items: []*cloudfront.PublicKeySummary{
+									&cloudfront.PublicKeySummary{
+										Id: aws.String("123"),
+									},
+								},
+							},
+						},
+						lpkerr: nil,
+					},
+				},
+			},
+			expectedErr: nil,
+			expectedOpt: map[string]cloudfront.ListPublicKeysOutput{
+				"test": {
+					PublicKeyList: &cloudfront.PublicKeyList{
+						Items: []*cloudfront.PublicKeySummary{
+							&cloudfront.PublicKeySummary{
+								Id: aws.String("123"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple region no error",
+			mocked: []*serviceConnector{
+				{
+					region: "test-1",
+					cloudfront: mockCloudFront{
+						lpko: &cloudfront.ListPublicKeysOutput{
+							PublicKeyList: &cloudfront.PublicKeyList{
+								Items: []*cloudfront.PublicKeySummary{
+									&cloudfront.PublicKeySummary{
+										Id: aws.String("123"),
+									},
+								},
+							},
+						},
+						lpkerr: nil,
+					},
+				},
+				{
+					region: "test-2",
+					cloudfront: mockCloudFront{
+						lpko: &cloudfront.ListPublicKeysOutput{
+							PublicKeyList: &cloudfront.PublicKeyList{
+								Items: []*cloudfront.PublicKeySummary{
+									&cloudfront.PublicKeySummary{
+										Id: aws.String("456"),
+									},
+								},
+							},
+						},
+						lpkerr: nil,
+					},
+				},
+			},
+			expectedErr: nil,
+			expectedOpt: map[string]cloudfront.ListPublicKeysOutput{
+				"test-1": {
+					PublicKeyList: &cloudfront.PublicKeyList{
+						Items: []*cloudfront.PublicKeySummary{
+							&cloudfront.PublicKeySummary{
+								Id: aws.String("123"),
+							},
+						},
+					},
+				},
+				"test-2": {
+					PublicKeyList: &cloudfront.PublicKeyList{
+						Items: []*cloudfront.PublicKeySummary{
+							&cloudfront.PublicKeySummary{
+								Id: aws.String("456"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple region with error",
+			mocked: []*serviceConnector{
+				{
+					region: "test-1",
+					cloudfront: mockCloudFront{
+						lpko:   &cloudfront.ListPublicKeysOutput{},
+						lpkerr: errors.New("error with test-1"),
+					},
+				},
+				{
+					region: "test-2",
+					cloudfront: mockCloudFront{
+						lpko: &cloudfront.ListPublicKeysOutput{
+							PublicKeyList: &cloudfront.PublicKeyList{
+								Items: []*cloudfront.PublicKeySummary{
+									&cloudfront.PublicKeySummary{
+										Id: aws.String("456"),
+									},
+								},
+							},
+						},
+						lpkerr: nil,
+					},
+				},
+			},
+			expectedErr: Errors{Error{
+				err:     errors.New("error with test-1"),
+				region:  "test-1",
+				service: cloudfront.ServiceName,
+			}},
+			expectedOpt: map[string]cloudfront.ListPublicKeysOutput{
+				"test-2": {
+					PublicKeyList: &cloudfront.PublicKeyList{
+						Items: []*cloudfront.PublicKeySummary{
+							&cloudfront.PublicKeySummary{
+								Id: aws.String("456"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var ctx = context.Background()
+
+	for i, tt := range tests {
+		c := &connector{svcs: tt.mocked}
+		opt, err := c.GetCloudFrontPublicKeys(ctx, nil)
 		checkErrors(t, tt.name, i, err, tt.expectedErr)
 		if !reflect.DeepEqual(opt, tt.expectedOpt) {
 			t.Errorf("%s [%d] - EC2 instances: received=%+v | expected=%+v",

--- a/cloudfront_test.go
+++ b/cloudfront_test.go
@@ -1,0 +1,198 @@
+package raws
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/aws/aws-sdk-go/service/cloudfront/cloudfrontiface"
+)
+
+type mockCloudFront struct {
+	cloudfrontiface.CloudFrontAPI
+
+	// Mock of DescribeInstances
+	ldo    *cloudfront.ListDistributionsOutput
+	ldoerr error
+}
+
+func (m mockCloudFront) ListDistributionsWithContext(
+	_ aws.Context, _ *cloudfront.ListDistributionsInput, _ ...request.Option,
+) (*cloudfront.ListDistributionsOutput, error) {
+	return m.ldo, m.ldoerr
+}
+
+func TestGetCloudFrontDistributions(t *testing.T) {
+	tests := []struct {
+		name        string
+		mocked      []*serviceConnector
+		expectedOpt map[string]cloudfront.ListDistributionsOutput
+		expectedErr error
+	}{
+		{
+			name: "one region with error",
+			mocked: []*serviceConnector{
+				{
+					region: "test",
+					cloudfront: mockCloudFront{
+						ldo:    &cloudfront.ListDistributionsOutput{},
+						ldoerr: errors.New("error with test"),
+					},
+				},
+			},
+			expectedErr: Errors{Error{
+				err:     errors.New("error with test"),
+				region:  "test",
+				service: cloudfront.ServiceName,
+			}},
+			expectedOpt: map[string]cloudfront.ListDistributionsOutput{},
+		},
+		{
+			name: "one region no error",
+			mocked: []*serviceConnector{
+				{
+					region: "test",
+					cloudfront: mockCloudFront{
+						ldo: &cloudfront.ListDistributionsOutput{
+							DistributionList: &cloudfront.DistributionList{
+								Items: []*cloudfront.DistributionSummary{
+									&cloudfront.DistributionSummary{
+										Id: aws.String("123"),
+									},
+								},
+							},
+						},
+						ldoerr: nil,
+					},
+				},
+			},
+			expectedErr: nil,
+			expectedOpt: map[string]cloudfront.ListDistributionsOutput{
+				"test": {
+					DistributionList: &cloudfront.DistributionList{
+						Items: []*cloudfront.DistributionSummary{
+							&cloudfront.DistributionSummary{
+								Id: aws.String("123"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple region no error",
+			mocked: []*serviceConnector{
+				{
+					region: "test-1",
+					cloudfront: mockCloudFront{
+						ldo: &cloudfront.ListDistributionsOutput{
+							DistributionList: &cloudfront.DistributionList{
+								Items: []*cloudfront.DistributionSummary{
+									&cloudfront.DistributionSummary{
+										Id: aws.String("123"),
+									},
+								},
+							},
+						},
+						ldoerr: nil,
+					},
+				},
+				{
+					region: "test-2",
+					cloudfront: mockCloudFront{
+						ldo: &cloudfront.ListDistributionsOutput{
+							DistributionList: &cloudfront.DistributionList{
+								Items: []*cloudfront.DistributionSummary{
+									&cloudfront.DistributionSummary{
+										Id: aws.String("456"),
+									},
+								},
+							},
+						},
+						ldoerr: nil,
+					},
+				},
+			},
+			expectedErr: nil,
+			expectedOpt: map[string]cloudfront.ListDistributionsOutput{
+				"test-1": {
+					DistributionList: &cloudfront.DistributionList{
+						Items: []*cloudfront.DistributionSummary{
+							&cloudfront.DistributionSummary{
+								Id: aws.String("123"),
+							},
+						},
+					},
+				},
+				"test-2": {
+					DistributionList: &cloudfront.DistributionList{
+						Items: []*cloudfront.DistributionSummary{
+							&cloudfront.DistributionSummary{
+								Id: aws.String("456"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple region with error",
+			mocked: []*serviceConnector{
+				{
+					region: "test-1",
+					cloudfront: mockCloudFront{
+						ldo:    &cloudfront.ListDistributionsOutput{},
+						ldoerr: errors.New("error with test-1"),
+					},
+				},
+				{
+					region: "test-2",
+					cloudfront: mockCloudFront{
+						ldo: &cloudfront.ListDistributionsOutput{
+							DistributionList: &cloudfront.DistributionList{
+								Items: []*cloudfront.DistributionSummary{
+									&cloudfront.DistributionSummary{
+										Id: aws.String("456"),
+									},
+								},
+							},
+						},
+						ldoerr: nil,
+					},
+				},
+			},
+			expectedErr: Errors{Error{
+				err:     errors.New("error with test-1"),
+				region:  "test-1",
+				service: cloudfront.ServiceName,
+			}},
+			expectedOpt: map[string]cloudfront.ListDistributionsOutput{
+				"test-2": {
+					DistributionList: &cloudfront.DistributionList{
+						Items: []*cloudfront.DistributionSummary{
+							&cloudfront.DistributionSummary{
+								Id: aws.String("456"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var ctx = context.Background()
+
+	for i, tt := range tests {
+		c := &connector{svcs: tt.mocked}
+		opt, err := c.GetCloudFrontDistributions(ctx, nil)
+		checkErrors(t, tt.name, i, err, tt.expectedErr)
+		if !reflect.DeepEqual(opt, tt.expectedOpt) {
+			t.Errorf("%s [%d] - EC2 instances: received=%+v | expected=%+v",
+				tt.name, i, opt, tt.expectedOpt)
+		}
+	}
+}

--- a/connector.go
+++ b/connector.go
@@ -167,6 +167,12 @@ type AWSReader interface {
 	GetCloudFrontDistributions(
 		ctx context.Context, input *cloudfront.ListDistributionsInput,
 	) (map[string]cloudfront.ListDistributionsOutput, error)
+
+	// GetCloudFrontPublicKeys returns all the CloudFront Public Keys on the given input
+	// Returned values are commented in the interface doc comment block.
+	GetCloudFrontPublicKeys(
+		ctx context.Context, input *cloudfront.ListPublicKeysInput,
+	) (map[string]cloudfront.ListPublicKeysOutput, error)
 }
 
 // NewAWSReader returns an object which also contains the accountID and extend the different regions to use.

--- a/connector.go
+++ b/connector.go
@@ -10,6 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+	"github.com/aws/aws-sdk-go/service/cloudfront/cloudfrontiface"
 	"github.com/aws/aws-sdk-go/service/configservice"
 	"github.com/aws/aws-sdk-go/service/configservice/configserviceiface"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -159,6 +161,12 @@ type AWSReader interface {
 	GetRecordedResourceCounts(
 		ctx context.Context, input *configservice.GetDiscoveredResourceCountsInput,
 	) (map[string]configservice.GetDiscoveredResourceCountsOutput, error)
+
+	// GetCloudFrontDistributions returns all the CloudFront Distributions on the given input
+	// Returned values are commented in the interface doc comment block.
+	GetCloudFrontDistributions(
+		ctx context.Context, input *cloudfront.ListDistributionsInput,
+	) (map[string]cloudfront.ListDistributionsOutput, error)
 }
 
 // NewAWSReader returns an object which also contains the accountID and extend the different regions to use.
@@ -232,6 +240,7 @@ type serviceConnector struct {
 	s3downloader  s3manageriface.DownloaderAPI
 	elasticache   elasticacheiface.ElastiCacheAPI
 	configservice configserviceiface.ConfigServiceAPI
+	cloudfront    cloudfrontiface.CloudFrontAPI
 }
 
 // configureAWS creates a new static credential with the passed accessKey and

--- a/connector.go
+++ b/connector.go
@@ -173,6 +173,12 @@ type AWSReader interface {
 	GetCloudFrontPublicKeys(
 		ctx context.Context, input *cloudfront.ListPublicKeysInput,
 	) (map[string]cloudfront.ListPublicKeysOutput, error)
+
+	// GetCloudFrontOriginAccessIdentities returns all the CloudFront Origin Access Identities on the given input
+	// Returned values are commented in the interface doc comment block.
+	GetCloudFrontOriginAccessIdentities(
+		ctx context.Context, input *cloudfront.ListCloudFrontOriginAccessIdentitiesInput,
+	) (map[string]cloudfront.ListCloudFrontOriginAccessIdentitiesOutput, error)
 }
 
 // NewAWSReader returns an object which also contains the accountID and extend the different regions to use.


### PR DESCRIPTION
This PR adds the:

* GetCloudFrontDistributions
* GetCloudFrontPublikKeys
* GetCloudFrontOriginAccessIdentities

Which is what we need to "tick" the `Cloudfront` from #8.