### PR TITLE
s3: update region logic for ListBuckets method

### DIFF
--- a/list_buckets.go
+++ b/list_buckets.go
@@ -3,6 +3,7 @@ package raws
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
@@ -31,7 +32,7 @@ func (c *connector) ListBuckets(ctx context.Context, input *s3.ListBucketsInput)
 				if err != nil {
 					errs = append(errs, NewError(svc.region, s3.ServiceName, err))
 				}
-				if *result.LocationConstraint == svc.region {
+				if s3.NormalizeBucketLocation(aws.StringValue(result.LocationConstraint)) == svc.region {
 					newOpt.Buckets = append(newOpt.Buckets, bucket)
 				}
 			}


### PR DESCRIPTION
The previous implementation was relying on 'GetBucketLocation' however
this seems flawed as the pointer could be `nil` (trigger panics), and
the returned result would not fully match the existing regions; as the
result of location are following:
https://github.com/aws/aws-sdk-go/blob/master/service/s3/api.go#L24385

So this would have worked only for a handful of cases. Using
GetBucketRegionWithClient should solve that, however it is not scoped to
any interface/struct, so it makes the testing more painful.

Closes: https://github.com/cycloidio/raws/issues/50